### PR TITLE
Setup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "private": true,
-  "scripts": {},
+  "scripts": {
+    "setup": "bash ./setup.sh"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script installs dependencies, builds, and runs Prisma code generation 
+# in your monorepo. It assumes the following folder structure at the root:
+#   /backend
+#   /common
+#   /frontend
+#   pnpm-workspace.yaml
+
+echo "=== Installing dependencies in /common ==="
+pushd common > /dev/null
+pnpm install
+popd > /dev/null
+
+echo "=== Installing dependencies in /backend ==="
+pushd backend > /dev/null
+pnpm install
+popd > /dev/null
+
+echo "=== Installing dependencies in /frontend ==="
+pushd frontend > /dev/null
+pnpm install
+popd > /dev/null
+
+echo "=== Building /common ==="
+pushd common > /dev/null
+pnpm run build
+popd > /dev/null
+
+echo "=== Generating Prisma types in /backend ==="
+pushd backend > /dev/null
+pnpm prisma generate
+popd > /dev/null
+
+echo "=== Building /backend ==="
+pushd backend > /dev/null
+pnpm run build
+popd > /dev/null
+
+echo "=== Setup complete! ==="


### PR DESCRIPTION
This PR made a bash script to setup environments in /backend, /frontend, and /common directories. Should run `chmod +x setup.sh` first to make it executable. Then simply run `pnpm run setup` or `./setup.sh` to execute the script.