### PR TITLE
Fix Image Upload Bugs

### DIFF
--- a/frontend/src/components/custom/UploadImageComponent.tsx
+++ b/frontend/src/components/custom/UploadImageComponent.tsx
@@ -29,10 +29,6 @@ function UploadImageComponent({
 	const [uploadedUrls, setUploadedUrls] = useState<string[]>([]);
 	const [isPending, startTransition] = useTransition();
 
-	console.log("Image Input Ref: ", imageInputRef.current?.value);
-
-	console.log("Uploaded URLs:", uploadedUrls);
-
 	const processFiles = async (files: File[]) => {
 		// Check if files are empty
 		if (!files.length) return;
@@ -133,7 +129,6 @@ function UploadImageComponent({
 			// Return everything from "fundraisers/" to the end of the string
 			removedUrl = removedUrl.substring(folderPos);
 		}
-		console.log("Removing image:", removedUrl);
 
 		// Update local state first (update the preview image urls by filtering out the removed image)
 		const newUrls = uploadedUrls.filter((_, index) => index !== indexToRemove);

--- a/frontend/src/components/custom/UploadImageComponent.tsx
+++ b/frontend/src/components/custom/UploadImageComponent.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import {
-	type ChangeEvent,
-	useRef,
-	useState,
-	useTransition,
-	type DragEvent,
+  type ChangeEvent,
+  useRef,
+  useState,
+  useTransition,
+  type DragEvent,
 } from "react";
 import Image from "next/image";
 import { uploadImage, deleteImage } from "@/utils/supabase/storage/client";
@@ -13,210 +13,213 @@ import { X, Upload } from "lucide-react";
 import { toast } from "sonner";
 
 interface UploadImageComponentProps {
-	imageUrls: string[];
-	setImageUrls: (newImageUrls: string[]) => void;
-	folder?: string;
-	allowMultiple?: boolean;
+  imageUrls: string[];
+  setImageUrls: (newImageUrls: string[]) => void;
+  folder?: string;
+  allowMultiple?: boolean;
 }
 
 function UploadImageComponent({
-	imageUrls,
-	setImageUrls,
-	folder,
-	allowMultiple,
+  imageUrls,
+  setImageUrls,
+  folder,
+  allowMultiple,
 }: UploadImageComponentProps) {
-	const imageInputRef = useRef<HTMLInputElement>(null);
-	const [uploadedUrls, setUploadedUrls] = useState<string[]>([]);
-	const [isPending, startTransition] = useTransition();
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const [uploadedUrls, setUploadedUrls] = useState<string[]>([]);
+  const [isPending, startTransition] = useTransition();
 
-	const processFiles = async (files: File[]) => {
-		// Check if files are empty
-		if (!files.length) return;
+  const processFiles = async (files: File[]) => {
+    // Check if files are empty
+    if (!files.length) return;
 
-		// Filter for only IMAGE files
-		const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-		if (imageFiles.length === 0) return;
+    // Filter for only IMAGE files
+    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+    if (imageFiles.length === 0) return;
 
-		// For single image upload, only use the first image
-		const filesToProcess = allowMultiple ? imageFiles : [imageFiles[0]];
+    // For single image upload, only use the first image
+    const filesToProcess = allowMultiple ? imageFiles : [imageFiles[0]];
 
-		startTransition(async () => {
-			const urls: string[] = [];
+    startTransition(async () => {
+      const urls: string[] = [];
 
-			for (const file of filesToProcess) {
-				try {
-					// If image has spaces in the name, replace them with underscores
-					// This is to avoid issues with file names when uploading
-					// regex \s+ matches one or more whitespace characters
-					// g is for global search (replace all occurrences of the pattern)
-					const filename = file.name.replace(/\s+/g, "_");
+      for (const file of filesToProcess) {
+        try {
+          // If image has spaces in the name, replace them with underscores
+          // This is to avoid issues with file names when uploading
+          // regex \s+ matches one or more whitespace characters
+          // g is for global search (replace all occurrences of the pattern)
+          const filename = file.name.replace(/\s+/g, "_");
 
-					// Generate a unique filename
-					const uniqueFilename = `${Date.now()}_${filename}`;
+          // Generate a unique filename
+          const uniqueFilename = `${Date.now()}_${filename}`;
 
-					const uniqueFile = new File([file], uniqueFilename, {
-						type: file.type,
-					});
+          const uniqueFile = new File([file], uniqueFilename, {
+            type: file.type,
+          });
 
-					const { imageUrl, error } = await uploadImage({
-						file: uniqueFile,
-						bucket: "images",
-						folder,
-					});
+          const { imageUrl, error } = await uploadImage({
+            file: uniqueFile,
+            bucket: "images",
+            folder,
+          });
 
-					if (!imageUrl) {
-						toast.error(error);
-						continue;
-					} else {
-						urls.push(imageUrl);
-					}
-				} catch (err) {
-					console.error("Error processing image:", err);
-				}
-			}
+          if (!imageUrl) {
+            toast.error(error);
+            continue;
+          } else {
+            urls.push(imageUrl);
+          }
+        } catch (err) {
+          console.error("Error processing image:", err);
+        }
+      }
 
-			if (urls.length > 0) {
-				setUploadedUrls((prev) =>
-					allowMultiple ? [...prev, ...urls] : [urls[0]]
-				);
-				// Set the image URLs in the parent component (this is for the form field values)
-				if (allowMultiple) {
-					setImageUrls([...imageUrls, ...urls]);
-				} else {
-					// For single item image
-					setImageUrls([urls[0]]);
-				}
-			}
-		});
-	};
+      if (urls.length > 0) {
+        setUploadedUrls((prev) =>
+          allowMultiple ? [...prev, ...urls] : [urls[0]]
+        );
+        // Set the image URLs in the parent component (this is for the form field values)
+        if (allowMultiple) {
+          setImageUrls([...imageUrls, ...urls]);
+        } else {
+          // For single item image
+          setImageUrls([urls[0]]);
+        }
+      }
+    });
+  };
 
-	// Handle file selection from the file input
-	// If user selects no files, do nothing
-	// If user selects files, convert files to an array and process them
-	const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
-		if (!e.target.files?.length) return;
-		const filesArray = Array.from(e.target.files);
-		await processFiles(filesArray);
-	};
+  // Handle file selection from the file input
+  // If user selects no files, do nothing
+  // If user selects files, convert files to an array and process them
+  const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files?.length) return;
+    const filesArray = Array.from(e.target.files);
+    await processFiles(filesArray);
+  };
 
-	const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
-		e.preventDefault();
-		e.stopPropagation();
-	};
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
 
-	const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
-		e.preventDefault();
-		e.stopPropagation();
-	};
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
 
-	const handleDrop = async (e: DragEvent<HTMLDivElement>) => {
-		e.preventDefault();
-		e.stopPropagation();
+  const handleDrop = async (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
 
-		// Check if files are dropped in
-		// If files are dropped, convert files to an array and process them
-		if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-			const filesArray = Array.from(e.dataTransfer.files);
-			await processFiles(filesArray);
-		}
-	};
+    // Check if files are dropped in
+    // If files are dropped, convert files to an array and process them
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      const filesArray = Array.from(e.dataTransfer.files);
+      await processFiles(filesArray);
+    }
+  };
 
-	const removeUploadedImage = async (indexToRemove: number) => {
-		// Get the URL that's being removed
-		let removedUrl = uploadedUrls[indexToRemove];
-		const folderPos = removedUrl.indexOf(`${folder}/`);
-		if (folderPos !== -1) {
-			// Return everything from "fundraisers/" to the end of the string
-			removedUrl = removedUrl.substring(folderPos);
-		}
+  const removeUploadedImage = async (indexToRemove: number) => {
+    // Get the URL that's being removed
+    let removedUrl = uploadedUrls[indexToRemove];
+    const folderPos = removedUrl.indexOf(`${folder}/`);
+    if (folderPos !== -1) {
+      // Return everything from "fundraisers/" to the end of the string
+      removedUrl = removedUrl.substring(folderPos);
+    }
 
-		// Update local state first (update the preview image urls by filtering out the removed image)
-		const newUrls = uploadedUrls.filter((_, index) => index !== indexToRemove);
-		setUploadedUrls(newUrls);
+    // Update local state first (update the preview image urls by filtering out the removed image)
+    const newUrls = uploadedUrls.filter((_, index) => index !== indexToRemove);
+    setUploadedUrls(newUrls);
 
-		// Or to delete an image using its full URL
-		const _ = await deleteImage({
-			bucket: "images",
-			path: removedUrl,
-		});
+    // Or to delete an image using its full URL
+    const _ = await deleteImage({
+      bucket: "images",
+      path: removedUrl,
+    });
 
-		// Then update parent component states (update form field values)
-		setImageUrls(imageUrls.filter((url) => url !== removedUrl));
+    // Then update parent component states (update form field values)
+    setImageUrls(imageUrls.filter((url) => url !== removedUrl));
 
-		// When an image is uploaded, the value of imageInputRef is set to the image path
-		// When we remove an image from the input, the value of the ref does not get reset thus
-		// the onChange event of input component does not get triggered.
-		// To allow the user to upload the same image again, we need to reset the value of the input
-		if (imageInputRef.current) {
-			imageInputRef.current.value = "";
-		}
-	};
+    // When an image is uploaded, the value of imageInputRef is set to the image path
+    // When we remove an image from the input, the value of the ref does not get reset thus
+    // the onChange event of input component does not get triggered.
+    // To allow the user to upload the same image again, we need to reset the value of the input
+    if (imageInputRef.current) {
+      imageInputRef.current.value = "";
+    }
+  };
 
-	return (
-		<div className="space-y-4">
-			<input
-				type="file"
-				hidden
-				multiple={allowMultiple}
-				ref={imageInputRef}
-				onChange={handleImageChange}
-				accept="image/*"
-				disabled={isPending}
-			/>
+  return (
+    <div className="space-y-4">
+      <input
+        type="file"
+        hidden
+        multiple={allowMultiple}
+        ref={imageInputRef}
+        onChange={handleImageChange}
+        accept="image/*"
+        disabled={isPending}
+      />
 
-			<div
-				className={`border-2 border-dashed rounded-lg p-6 transition-colors`}
-				onDragOver={handleDragOver}
-				onDragLeave={handleDragLeave}
-				onDrop={handleDrop}
-				onClick={() => imageInputRef.current?.click()}>
-				<div className="flex flex-col items-center justify-center space-y-2 text-center">
-					<Upload className="h-10 w-10 text-gray-400" />
-					<p className="text-sm text-gray-500">
-						<span className="font-semibold text-primary cursor-pointer">
-							Click to upload
-						</span>{" "}
-						or drag and drop
-					</p>
-					<p className="text-xs text-gray-500">
-						{allowMultiple ? "Upload multiple images" : "Upload a single image"}
-					</p>
-					{isPending && (
-						<div className="mt-2">
-							<div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto"></div>
-							<p className="text-xs text-gray-500 mt-1">Uploading...</p>
-						</div>
-					)}
-				</div>
-			</div>
+      <div
+        className={`border-2 border-dashed rounded-lg p-6 transition-colors`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClick={() => imageInputRef.current?.click()}
+      >
+        <div className="flex flex-col items-center justify-center space-y-2 text-center">
+          <Upload className="h-10 w-10 text-gray-400" />
+          <p className="text-sm text-gray-500">
+            <span className="font-semibold text-primary cursor-pointer">
+              Click to upload
+            </span>{" "}
+            or drag and drop
+          </p>
+          <p className="text-xs text-gray-500">
+            {allowMultiple ? "Upload multiple images" : "Upload a single image"}
+          </p>
+          {isPending && (
+            <div className="mt-2">
+              <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto"></div>
+              <p className="text-xs text-gray-500 mt-1">Uploading...</p>
+            </div>
+          )}
+        </div>
+      </div>
 
-			{uploadedUrls.length > 0 && (
-				<div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2">
-					{/* Show uploaded images */}
-					{uploadedUrls.map((url, index) => (
-						<div
-							key={index}
-							className="relative aspect-video bg-gray-50 rounded-md border overflow-hidden group min-h-[150px]">
-							<Image
-								src={url || "/placeholder.svg"}
-								fill
-								sizes="(max-width: 768px) 50vw, 33vw"
-								alt={`Uploaded image ${index + 1}`}
-								className="object-contain p-1"
-							/>
-							<button
-								type="button"
-								onClick={() => removeUploadedImage(index)}
-								className="absolute top-1 right-1 bg-red-500 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
-								aria-label="Remove image">
-								<X className="h-3 w-3" />
-							</button>
-						</div>
-					))}
-				</div>
-			)}
-		</div>
-	);
+      {uploadedUrls.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2">
+          {/* Show uploaded images */}
+          {uploadedUrls.map((url, index) => (
+            <div
+              key={index}
+              className="relative aspect-video bg-gray-50 rounded-md border overflow-hidden group min-h-[150px]"
+            >
+              <Image
+                src={url || "/placeholder.svg"}
+                fill
+                sizes="(max-width: 768px) 50vw, 33vw"
+                alt={`Uploaded image ${index + 1}`}
+                className="object-contain p-1"
+              />
+              <button
+                type="button"
+                onClick={() => removeUploadedImage(index)}
+                className="absolute top-1 right-1 bg-red-500 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                aria-label="Remove image"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default UploadImageComponent;

--- a/frontend/src/components/custom/UploadImageComponent.tsx
+++ b/frontend/src/components/custom/UploadImageComponent.tsx
@@ -1,216 +1,219 @@
 "use client";
 
 import {
-  type ChangeEvent,
-  useRef,
-  useState,
-  useTransition,
-  type DragEvent,
+	type ChangeEvent,
+	useRef,
+	useState,
+	useTransition,
+	type DragEvent,
 } from "react";
 import Image from "next/image";
-import { uploadImage } from "@/utils/supabase/storage/client";
+import { uploadImage, deleteImage } from "@/utils/supabase/storage/client";
 import { X, Upload } from "lucide-react";
 import { toast } from "sonner";
 
 interface UploadImageComponentProps {
-  imageUrls: string[];
-  setImageUrls: (newImageUrls: string[]) => void;
-  folder?: string;
-  allowMultiple?: boolean;
+	imageUrls: string[];
+	setImageUrls: (newImageUrls: string[]) => void;
+	folder?: string;
+	allowMultiple?: boolean;
 }
 
 function UploadImageComponent({
-  imageUrls,
-  setImageUrls,
-  folder,
-  allowMultiple,
+	imageUrls,
+	setImageUrls,
+	folder,
+	allowMultiple,
 }: UploadImageComponentProps) {
-  const imageInputRef = useRef<HTMLInputElement>(null);
-  const [numUploading, setNumUploading] = useState<number>(0);
-  const [uploadedUrls, setUploadedUrls] = useState<string[]>([]);
-  const [isPending, startTransition] = useTransition();
-  const [isDragging, setIsDragging] = useState(false);
+	const imageInputRef = useRef<HTMLInputElement>(null);
+	const [numUploading, setNumUploading] = useState<number>(0);
+	const [uploadedUrls, setUploadedUrls] = useState<string[]>([]);
+	const [isPending, startTransition] = useTransition();
+	const [isDragging, setIsDragging] = useState(false);
 
-  const processFiles = async (files: File[]) => {
-    if (!files.length) return;
+	const processFiles = async (files: File[]) => {
+		if (!files.length) return;
 
-    // Filter for only image files
-    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) return;
+		// Filter for only image files
+		const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+		if (imageFiles.length === 0) return;
 
-    // For single image upload, only use the first image
-    const filesToProcess = allowMultiple ? imageFiles : [imageFiles[0]];
+		// For single image upload, only use the first image
+		const filesToProcess = allowMultiple ? imageFiles : [imageFiles[0]];
 
-    const newImageUrls = filesToProcess.map((file) =>
-      URL.createObjectURL(file)
-    );
+		const newImageUrls = filesToProcess.map((file) =>
+			URL.createObjectURL(file)
+		);
 
-    setNumUploading(newImageUrls.length);
+		setNumUploading(newImageUrls.length);
 
-    // Automatically upload
-    startTransition(async () => {
-      const urls: string[] = [];
+		startTransition(async () => {
+			const urls: string[] = [];
 
-      for (const file of filesToProcess) {
-        try {
-          const { imageUrl, error } = await uploadImage({
-            file,
-            bucket: "images",
-            folder,
-          });
+			for (const file of filesToProcess) {
+				try {
+					const { imageUrl, error } = await uploadImage({
+						file,
+						bucket: "images",
+						folder,
+					});
 
-          if (!imageUrl) {
-            toast.error(error);
-            continue;
-          } else {
-            urls.push(imageUrl);
-          }
-        } catch (err) {
-          console.error("Error processing image:", err);
-        }
-      }
+					if (!imageUrl) {
+						toast.error(error);
+						continue;
+					} else {
+						urls.push(imageUrl);
+					}
+				} catch (err) {
+					console.error("Error processing image:", err);
+				}
+			}
 
-      if (urls.length > 0) {
-        setUploadedUrls((prev) =>
-          allowMultiple ? [...prev, ...urls] : [urls[0]]
-        );
+			if (urls.length > 0) {
+				setUploadedUrls((prev) =>
+					allowMultiple ? [...prev, ...urls] : [urls[0]]
+				);
 
-        // populate parent component's fields
-        if (allowMultiple) {
-          setImageUrls([...imageUrls, ...urls]);
-        } else {
-          // For single item image
-          setImageUrls([urls[0]]);
-        }
+				// populate parent component's fields
+				if (allowMultiple) {
+					setImageUrls([...imageUrls, ...urls]);
+				} else {
+					// For single item image
+					setImageUrls([urls[0]]);
+				}
 
-        setNumUploading(0);
-      }
-    });
-  };
+				setNumUploading(0);
+			}
+		});
+	};
 
-  const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
-    if (!e.target.files?.length) return;
-    const filesArray = Array.from(e.target.files);
-    await processFiles(filesArray);
-  };
+	const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
+		if (!e.target.files?.length) return;
+		const filesArray = Array.from(e.target.files);
+		await processFiles(filesArray);
+	};
 
-  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(true);
-  };
+	const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setIsDragging(true);
+	};
 
-  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
-  };
+	const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setIsDragging(false);
+	};
 
-  const handleDrop = async (e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
+	const handleDrop = async (e: DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setIsDragging(false);
 
-    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-      const filesArray = Array.from(e.dataTransfer.files);
-      await processFiles(filesArray);
-    }
-  };
+		if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+			const filesArray = Array.from(e.dataTransfer.files);
+			await processFiles(filesArray);
+		}
+	};
 
-  const removeUploadedImage = (indexToRemove: number) => {
-    // Get the URL that's being removed
-    const removedUrl = uploadedUrls[indexToRemove];
+	const removeUploadedImage = async (indexToRemove: number) => {
+		// Get the URL that's being removed
+		const removedUrl = uploadedUrls[indexToRemove];
+		console.log("Removed URL:", removedUrl);
 
-    // Update local state first
-    const newUrls = uploadedUrls.filter((_, index) => index !== indexToRemove);
-    setUploadedUrls(newUrls);
+		// Update local state first
+		const newUrls = uploadedUrls.filter((_, index) => index !== indexToRemove);
+		setUploadedUrls(newUrls);
 
-    // Then update parent component states
-    setImageUrls(imageUrls.filter((url) => url !== removedUrl));
-  };
+		// Or to delete an image using its full URL
+		const result = await deleteImage({
+			bucket: "images",
+			path: removedUrl,
+		});
 
-  return (
-    <div className="space-y-4">
-      <input
-        type="file"
-        hidden
-        multiple={allowMultiple}
-        ref={imageInputRef}
-        onChange={handleImageChange}
-        accept="image/*"
-        disabled={isPending}
-      />
+		// Then update parent component states
+		setImageUrls(imageUrls.filter((url) => url !== removedUrl));
+	};
 
-      <div
-        className={`border-2 border-dashed rounded-lg p-6 transition-colors ${
-          isDragging
-            ? "border-primary bg-primary/10"
-            : "border-gray-300 hover:border-primary/50"
-        }`}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-        onClick={() => imageInputRef.current?.click()}
-      >
-        <div className="flex flex-col items-center justify-center space-y-2 text-center">
-          <Upload className="h-10 w-10 text-gray-400" />
-          <p className="text-sm text-gray-500">
-            <span className="font-semibold text-primary cursor-pointer">
-              Click to upload
-            </span>{" "}
-            or drag and drop
-          </p>
-          <p className="text-xs text-gray-500">
-            {allowMultiple ? "Upload multiple images" : "Upload a single image"}
-          </p>
-          {isPending && (
-            <div className="mt-2">
-              <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto"></div>
-              <p className="text-xs text-gray-500 mt-1">Uploading...</p>
-            </div>
-          )}
-        </div>
-      </div>
+	return (
+		<div className="space-y-4">
+			<input
+				type="file"
+				hidden
+				multiple={allowMultiple}
+				ref={imageInputRef}
+				onChange={handleImageChange}
+				accept="image/*"
+				disabled={isPending}
+			/>
 
-      {uploadedUrls.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2">
-          {/* Show uploaded images */}
-          {uploadedUrls.map((url, index) => (
-            <div
-              key={index}
-              className="relative aspect-video bg-gray-50 rounded-md border overflow-hidden group min-h-[150px]"
-            >
-              <Image
-                src={url || "/placeholder.svg"}
-                fill
-                sizes="(max-width: 768px) 50vw, 33vw"
-                alt={`Uploaded image ${index + 1}`}
-                className="object-contain p-1"
-              />
-              <button
-                type="button"
-                onClick={() => removeUploadedImage(index)}
-                className="absolute top-1 right-1 bg-red-500 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
-                aria-label="Remove image"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          ))}
+			<div
+				className={`border-2 border-dashed rounded-lg p-6 transition-colors ${
+					isDragging
+						? "border-primary bg-primary/10"
+						: "border-gray-300 hover:border-primary/50"
+				}`}
+				onDragOver={handleDragOver}
+				onDragLeave={handleDragLeave}
+				onDrop={handleDrop}
+				onClick={() => imageInputRef.current?.click()}>
+				<div className="flex flex-col items-center justify-center space-y-2 text-center">
+					<Upload className="h-10 w-10 text-gray-400" />
+					<p className="text-sm text-gray-500">
+						<span className="font-semibold text-primary cursor-pointer">
+							Click to upload
+						</span>{" "}
+						or drag and drop
+					</p>
+					<p className="text-xs text-gray-500">
+						{allowMultiple ? "Upload multiple images" : "Upload a single image"}
+					</p>
+					{isPending && (
+						<div className="mt-2">
+							<div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto"></div>
+							<p className="text-xs text-gray-500 mt-1">Uploading...</p>
+						</div>
+					)}
+				</div>
+			</div>
 
-          {/* Show uploading previews */}
-          {numUploading > 0 &&
-            Array.from({ length: numUploading }, (_, i) => (
-              <div key={i} className="relative bg-gray-100 rounded-md ">
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
-                </div>
-              </div>
-            ))}
-        </div>
-      )}
-    </div>
-  );
+			{uploadedUrls.length > 0 && (
+				<div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2">
+					{/* Show uploaded images */}
+					{uploadedUrls.map((url, index) => (
+						<div
+							key={index}
+							className="relative aspect-video bg-gray-50 rounded-md border overflow-hidden group min-h-[150px]">
+							<Image
+								src={url || "/placeholder.svg"}
+								fill
+								sizes="(max-width: 768px) 50vw, 33vw"
+								alt={`Uploaded image ${index + 1}`}
+								className="object-contain p-1"
+							/>
+							<button
+								type="button"
+								onClick={() => removeUploadedImage(index)}
+								className="absolute top-1 right-1 bg-red-500 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+								aria-label="Remove image">
+								<X className="h-3 w-3" />
+							</button>
+						</div>
+					))}
+
+					{/* Show uploading previews */}
+					{numUploading > 0 &&
+						Array.from({ length: numUploading }, (_, i) => (
+							<div key={i} className="relative bg-gray-100 rounded-md ">
+								<div className="absolute inset-0 flex items-center justify-center">
+									<div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
+								</div>
+							</div>
+						))}
+				</div>
+			)}
+		</div>
+	);
 }
 
 export default UploadImageComponent;

--- a/frontend/src/components/custom/UploadImageComponent.tsx
+++ b/frontend/src/components/custom/UploadImageComponent.tsx
@@ -45,8 +45,14 @@ function UploadImageComponent({
 
 			for (const file of filesToProcess) {
 				try {
+					// If image has spaces in the name, replace them with underscores
+					// This is to avoid issues with file names when uploading
+					// regex \s+ matches one or more whitespace characters
+					// g is for global search (replace all occurrences of the pattern)
+					const filename = file.name.replace(/\s+/g, "_");
+
 					// Generate a unique filename
-					const uniqueFilename = `${Date.now()}_${file.name}`;
+					const uniqueFilename = `${Date.now()}_${filename}`;
 
 					const uniqueFile = new File([file], uniqueFilename, {
 						type: file.type,
@@ -117,7 +123,13 @@ function UploadImageComponent({
 
 	const removeUploadedImage = async (indexToRemove: number) => {
 		// Get the URL that's being removed
-		const removedUrl = uploadedUrls[indexToRemove];
+		let removedUrl = uploadedUrls[indexToRemove];
+		const folderPos = removedUrl.indexOf(`${folder}/`);
+		if (folderPos !== -1) {
+			// Return everything from "fundraisers/" to the end of the string
+			removedUrl = removedUrl.substring(folderPos);
+		}
+		console.log("Removing image:", removedUrl);
 
 		// Update local state first (update the preview image urls by filtering out the removed image)
 		const newUrls = uploadedUrls.filter((_, index) => index !== indexToRemove);

--- a/frontend/src/components/custom/UploadImageComponent.tsx
+++ b/frontend/src/components/custom/UploadImageComponent.tsx
@@ -29,6 +29,10 @@ function UploadImageComponent({
 	const [uploadedUrls, setUploadedUrls] = useState<string[]>([]);
 	const [isPending, startTransition] = useTransition();
 
+	console.log("Image Input Ref: ", imageInputRef.current?.value);
+
+	console.log("Uploaded URLs:", uploadedUrls);
+
 	const processFiles = async (files: File[]) => {
 		// Check if files are empty
 		if (!files.length) return;
@@ -143,6 +147,14 @@ function UploadImageComponent({
 
 		// Then update parent component states (update form field values)
 		setImageUrls(imageUrls.filter((url) => url !== removedUrl));
+
+		// When an image is uploaded, the value of imageInputRef is set to the image path
+		// When we remove an image from the input, the value of the ref does not get reset thus
+		// the onChange event of input component does not get triggered.
+		// To allow the user to upload the same image again, we need to reset the value of the input
+		if (imageInputRef.current) {
+			imageInputRef.current.value = "";
+		}
 	};
 
 	return (

--- a/frontend/src/utils/supabase/storage/client.ts
+++ b/frontend/src/utils/supabase/storage/client.ts
@@ -2,56 +2,119 @@ import imageCompression from "browser-image-compression";
 import { createClient } from "../client";
 
 export const uploadImage = async ({
-  file,
-  bucket,
-  folder,
+	file,
+	bucket,
+	folder,
 }: {
-  file: File;
-  bucket: string;
-  folder?: string;
+	file: File;
+	bucket: string;
+	folder?: string;
 }): Promise<
-  | {
-      imageUrl: string;
-      error: null;
-    }
-  | {
-      imageUrl: null;
-      error: string;
-    }
+	| {
+			imageUrl: string;
+			error: null;
+	  }
+	| {
+			imageUrl: null;
+			error: string;
+	  }
 > => {
-  const fileName = file.name;
-  const path = `${folder ? folder + "/" : ""}${fileName}`;
+	const fileName = file.name;
+	const path = `${folder ? folder + "/" : ""}${fileName}`;
 
-  try {
-    file = await imageCompression(file, {
-      maxSizeMB: 1,
-    });
-  } catch (error) {
-    console.error(error);
-    return {
-      imageUrl: null,
-      error: "Error compressing image",
-    };
-  }
+	try {
+		file = await imageCompression(file, {
+			maxSizeMB: 1,
+		});
+	} catch (error) {
+		console.error(error);
+		return {
+			imageUrl: null,
+			error: "Error compressing image",
+		};
+	}
 
-  const supabase = createClient();
+	const supabase = createClient();
 
-  const { data, error } = await supabase.storage
-    .from(bucket)
-    .upload(path, file);
+	const { data, error } = await supabase.storage
+		.from(bucket)
+		.upload(path, file);
 
-  if (error) {
-    console.error(error.message);
+	if (error) {
+		console.error(error.message);
 
-    return {
-      imageUrl: null,
-      error: `Error uploading image: ${error.message}`,
-    };
-  }
-  const imageUrl = `${process.env
-    .NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/${bucket}/${
-    data.path
-  }`;
+		return {
+			imageUrl: null,
+			error: `Error uploading image: ${error.message}`,
+		};
+	}
+	const imageUrl = `${process.env
+		.NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/${bucket}/${
+		data.path
+	}`;
 
-  return { imageUrl, error: null };
+	return { imageUrl, error: null };
+};
+
+export const deleteImage = async ({
+	bucket,
+	path,
+}: {
+	bucket: string;
+	path: string;
+}): Promise<
+	| {
+			success: true;
+			error: null;
+	  }
+	| {
+			success: false;
+			error: string;
+	  }
+> => {
+	// Early return if path is empty or undefined
+	if (!path) {
+		return {
+			success: false,
+			error: "No path provided for image deletion",
+		};
+	}
+
+	const supabase = createClient();
+
+	// Remove any URL prefix to get just the path part after the bucket
+	let cleanPath = path;
+
+	// If the path contains the full URL, extract just the path portion
+	if (path.includes("/storage/v1/object/public/")) {
+		// Parse out the path after the bucket name
+		try {
+			const urlParts = path.split(`/${bucket}/`);
+			if (urlParts.length > 1) {
+				cleanPath = urlParts[1];
+			}
+		} catch (error) {
+			console.error("Error parsing image path:", error);
+			return {
+				success: false,
+				error: "Invalid image path format",
+			};
+		}
+	}
+
+	// Perform the deletion
+	const { error } = await supabase.storage.from(bucket).remove([cleanPath]);
+
+	if (error) {
+		console.error("Error deleting image:", error.message);
+		return {
+			success: false,
+			error: `Error deleting image: ${error.message}`,
+		};
+	}
+
+	return {
+		success: true,
+		error: null,
+	};
 };

--- a/frontend/src/utils/supabase/storage/client.ts
+++ b/frontend/src/utils/supabase/storage/client.ts
@@ -4,121 +4,121 @@ import { createClient } from "../client";
 /**
  * `uploadImage` is an asynchronous function that uploads an IMAGE file to a specified
  * bucket in Supabase storage.
- * 
+ *
  * @remarks
  * This functions is used in the `UploadImageComponent` component to upload images to Supabase storage.
- * It compresses large images files to a maximum size of 1MB before uploading (Supabase Storage has limit 
+ * It compresses large images files to a maximum size of 1MB before uploading (Supabase Storage has limit
  * on the size of files that can be uploaded). Then, it constructs the public URL for the uploaded image.
- * 
+ *
  * @param file - The image file to be uploaded.
  * @param bucket - The name of the Supabase storage bucket ("images" ) where the image will be uploaded.
  * @param folder - A folder (e.g fundraisers, items) path within the bucket where the image will be stored.
-*/
+ */
 export const uploadImage = async ({
-	file,
-	bucket,
-	folder,
+  file,
+  bucket,
+  folder,
 }: {
-	file: File;
-	bucket: string;
-	folder?: string;
+  file: File;
+  bucket: string;
+  folder?: string;
 }): Promise<
-	| {
-			imageUrl: string;
-			error: null;
-	  }
-	| {
-			imageUrl: null;
-			error: string;
-	  }
+  | {
+      imageUrl: string;
+      error: null;
+    }
+  | {
+      imageUrl: null;
+      error: string;
+    }
 > => {
-	const fileName = file.name;
-	const path = `${folder ? folder + "/" : ""}${fileName}`;
+  const fileName = file.name;
+  const path = `${folder ? folder + "/" : ""}${fileName}`;
 
-	try {
-		file = await imageCompression(file, {
-			maxSizeMB: 1,
-		});
-	} catch (error) {
-		console.error(error);
-		return {
-			imageUrl: null,
-			error: "Error compressing image",
-		};
-	}
+  try {
+    file = await imageCompression(file, {
+      maxSizeMB: 1,
+    });
+  } catch (error) {
+    console.error(error);
+    return {
+      imageUrl: null,
+      error: "Error compressing image",
+    };
+  }
 
-	const supabase = createClient();
+  const supabase = createClient();
 
-	const { data, error } = await supabase.storage
-		.from(bucket)
-		.upload(path, file);
+  const { data, error } = await supabase.storage
+    .from(bucket)
+    .upload(path, file);
 
-	if (error) {
-		console.error(error.message);
+  if (error) {
+    console.error(error.message);
 
-		return {
-			imageUrl: null,
-			error: `Error uploading image: ${error.message}`,
-		};
-	}
-	const imageUrl = `${process.env
-		.NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/${bucket}/${
-		data.path
-	}`;
+    return {
+      imageUrl: null,
+      error: `Error uploading image: ${error.message}`,
+    };
+  }
+  const imageUrl = `${process.env
+    .NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/${bucket}/${
+    data.path
+  }`;
 
-	return { imageUrl, error: null };
+  return { imageUrl, error: null };
 };
 
 /**
  * `deleteImage` is an asynchronous function that deletes an image file from a specified
  * bucket in Supabase storage.
- * 
+ *
  * @remarks
  * This functions is used in the `UploadImageComponent` component to delete images from Supabase storage
  * when the user removes an image. It extracts the path from the full URL if necessary,
- * 
+ *
  * @param bucket - The name of the Supabase storage bucket ("images" ) where the image is stored
  * @param path - The path to the image file in the bucket. This can be a full URL or just the path.
-*/
+ */
 export const deleteImage = async ({
-	bucket,
-	path,
+  bucket,
+  path,
 }: {
-	bucket: string;
-	path: string;
+  bucket: string;
+  path: string;
 }): Promise<
-	| {
-			success: true;
-			error: null;
-	  }
-	| {
-			success: false;
-			error: string;
-	  }
+  | {
+      success: true;
+      error: null;
+    }
+  | {
+      success: false;
+      error: string;
+    }
 > => {
-	// If no path is provided, return an error
-	if (!path) {
-		return {
-			success: false,
-			error: "No path provided for image deletion",
-		};
-	}
+  // If no path is provided, return an error
+  if (!path) {
+    return {
+      success: false,
+      error: "No path provided for image deletion",
+    };
+  }
 
-	const supabase = createClient();
+  const supabase = createClient();
 
-	// Perform the deletion
-	const { error } = await supabase.storage.from(bucket).remove([path]);
+  // Perform the deletion
+  const { error } = await supabase.storage.from(bucket).remove([path]);
 
-	if (error) {
-		console.error("Error deleting image:", error.message);
-		return {
-			success: false,
-			error: `Error deleting image: ${error.message}`,
-		};
-	}
+  if (error) {
+    console.error("Error deleting image:", error.message);
+    return {
+      success: false,
+      error: `Error deleting image: ${error.message}`,
+    };
+  }
 
-	return {
-		success: true,
-		error: null,
-	};
+  return {
+    success: true,
+    error: null,
+  };
 };

--- a/frontend/src/utils/supabase/storage/client.ts
+++ b/frontend/src/utils/supabase/storage/client.ts
@@ -1,6 +1,19 @@
 import imageCompression from "browser-image-compression";
 import { createClient } from "../client";
 
+/**
+ * `uploadImage` is an asynchronous function that uploads an IMAGE file to a specified
+ * bucket in Supabase storage.
+ * 
+ * @remarks
+ * This functions is used in the `UploadImageComponent` component to upload images to Supabase storage.
+ * It compresses large images files to a maximum size of 1MB before uploading (Supabase Storage has limit 
+ * on the size of files that can be uploaded). Then, it constructs the public URL for the uploaded image.
+ * 
+ * @param file - The image file to be uploaded.
+ * @param bucket - The name of the Supabase storage bucket ("images" ) where the image will be uploaded.
+ * @param folder - A folder (e.g fundraisers, items) path within the bucket where the image will be stored.
+*/
 export const uploadImage = async ({
 	file,
 	bucket,
@@ -56,6 +69,17 @@ export const uploadImage = async ({
 	return { imageUrl, error: null };
 };
 
+/**
+ * `deleteImage` is an asynchronous function that deletes an image file from a specified
+ * bucket in Supabase storage.
+ * 
+ * @remarks
+ * This functions is used in the `UploadImageComponent` component to delete images from Supabase storage
+ * when the user removes an image. It extracts the path from the full URL if necessary,
+ * 
+ * @param bucket - The name of the Supabase storage bucket ("images" ) where the image is stored
+ * @param path - The path to the image file in the bucket. This can be a full URL or just the path.
+*/
 export const deleteImage = async ({
 	bucket,
 	path,
@@ -72,7 +96,7 @@ export const deleteImage = async ({
 			error: string;
 	  }
 > => {
-	// Early return if path is empty or undefined
+	// If no path is provided, return an error
 	if (!path) {
 		return {
 			success: false,
@@ -82,28 +106,8 @@ export const deleteImage = async ({
 
 	const supabase = createClient();
 
-	// Remove any URL prefix to get just the path part after the bucket
-	let cleanPath = path;
-
-	// If the path contains the full URL, extract just the path portion
-	if (path.includes("/storage/v1/object/public/")) {
-		// Parse out the path after the bucket name
-		try {
-			const urlParts = path.split(`/${bucket}/`);
-			if (urlParts.length > 1) {
-				cleanPath = urlParts[1];
-			}
-		} catch (error) {
-			console.error("Error parsing image path:", error);
-			return {
-				success: false,
-				error: "Invalid image path format",
-			};
-		}
-	}
-
 	// Perform the deletion
-	const { error } = await supabase.storage.from(bucket).remove([cleanPath]);
+	const { error } = await supabase.storage.from(bucket).remove([path]);
 
 	if (error) {
 		console.error("Error deleting image:", error.message);


### PR DESCRIPTION
This PR addresses these bugs related to image upload to supabase:
- user cannot upload the same image more than once
- for screenshot img (e.g Screenshot 2025-04-18 at 5.48.53 PM), the prev PR did not reconstruct the file name, the whitespaces makes the image invalid for upload to supabase storage bucket
- when user removes an image, the user was not permitted to click and upload same image (this was due to the Ref object of the input component)

1) Implemented `deleteImage` function to remove an image from supabase storage bucket
2) Reformatted file name (addressing inconsistent whitespaces) before upload
3) Cleared `imageInputRef.value` after removing image

https://github.com/user-attachments/assets/c71fc900-f361-448c-8d06-6db84e874baa

*Note at the end of the video, the same image can be reuploaded*


