### PR TITLE
Move venmo info from org to fundraiser

### DIFF
--- a/backend/prisma/migrations/20250928211346_move_venmo_from_org_to_fundraiser/migration.sql
+++ b/backend/prisma/migrations/20250928211346_move_venmo_from_org_to_fundraiser/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `venmo_forwarding_verified` on the `organizations` table. All the data in the column will be lost.
+  - You are about to drop the column `venmo_username` on the `organizations` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "organizations_venmo_username_key";
+
+-- AlterTable
+ALTER TABLE "fundraisers" ADD COLUMN     "venmo_username" TEXT;
+
+-- AlterTable
+ALTER TABLE "organizations" DROP COLUMN "venmo_forwarding_verified",
+DROP COLUMN "venmo_username";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,16 +22,14 @@ model User {
 }
 
 model Organization {
-  id                      String   @id @default(uuid()) @db.Uuid
-  name                    String   @unique
-  description             String
-  authorized              Boolean  @default(false)
-  logoUrl                 String?  @map("logo_url")
-  websiteUrl              String?  @map("website_url")
-  instagramUsername       String?  @map("instagram_username")
-  venmoUsername           String?  @unique @map("venmo_username")
-  venmoForwardingVerified Boolean  @default(false) @map("venmo_forwarding_verified")
-  createdAt               DateTime @default(now()) @map("created_at")
+  id                String   @id @default(uuid()) @db.Uuid
+  name              String   @unique
+  description       String
+  authorized        Boolean  @default(false)
+  logoUrl           String?  @map("logo_url")
+  websiteUrl        String?  @map("website_url")
+  instagramUsername String?  @map("instagram_username")
+  createdAt         DateTime @default(now()) @map("created_at")
 
   admins      User[]
   fundraisers Fundraiser[]
@@ -43,6 +41,7 @@ model Fundraiser {
   id             String   @id @default(uuid()) @db.Uuid
   name           String
   description    String
+  venmoUsername  String?  @map("venmo_username")
   goalAmount     Decimal? @map("goal_amount") @db.Money
   pickupLocation String   @map("pickup_location")
   imageUrls      String[] @map("image_urls")

--- a/backend/src/api/fundraiser/fundraiser.services.ts
+++ b/backend/src/api/fundraiser/fundraiser.services.ts
@@ -110,6 +110,7 @@ export const createFundraiser = async (
     data: {
       name: fundraiserBody.name,
       description: fundraiserBody.description,
+      venmoUsername: fundraiserBody.venmoUsername,
       goalAmount: fundraiserBody.goalAmount,
       pickupLocation: fundraiserBody.pickupLocation,
       imageUrls: fundraiserBody.imageUrls,
@@ -143,6 +144,7 @@ export const updateFundraiser = async (
     data: {
       name: fundraiserBody.name,
       description: fundraiserBody.description,
+      venmoUsername: fundraiserBody.venmoUsername ?? null,
       goalAmount: fundraiserBody.goalAmount ?? null,
       pickupLocation: fundraiserBody.pickupLocation,
       imageUrls: fundraiserBody.imageUrls,

--- a/backend/src/api/organization/organization.services.ts
+++ b/backend/src/api/organization/organization.services.ts
@@ -39,7 +39,6 @@ export const createOrganization = async (
       logoUrl: organizationBody.logoUrl,
       websiteUrl: organizationBody.websiteUrl,
       instagramUsername: organizationBody.instagramUsername,
-      venmoUsername: organizationBody.venmoUsername,
 
       admins: {
         connect: [
@@ -69,7 +68,6 @@ export const updateOrganization = async (
       logoUrl: organizationBody.logoUrl ?? null,
       websiteUrl: organizationBody.websiteUrl ?? null,
       instagramUsername: organizationBody.instagramUsername ?? null,
-      venmoUsername: organizationBody.venmoUsername ?? null,
 
       admins: {
         connect: organizationBody.addedAdminsIds?.map((id) => ({ id })), // TODO: possible bug

--- a/common/schemas/fundraiser.ts
+++ b/common/schemas/fundraiser.ts
@@ -12,6 +12,7 @@ export const BasicFundraiserSchema = z.object({
   id: z.string().uuid(),
   name: z.string().min(1).max(255),
   description: z.string(),
+  venmoUsername: z.string().min(1).max(255).nullish(),
   goalAmount: MoneySchema.nullish(),
   pickupLocation: z.string(),
   buyingStartsAt: z.coerce.date(),
@@ -31,6 +32,13 @@ export const CompleteFundraiserSchema = BasicFundraiserSchema.extend({
 export const CreateFundraiserBody = z.object({
   name: z.string().min(1).max(255),
   description: z.string(),
+  venmoUsername: z
+    .string()
+    .optional()
+    .transform((value) =>
+      value ? (value.length === 0 ? undefined : value) : undefined
+    )
+    .pipe(z.string().min(5).max(30).optional()),
   imageUrls: z.array(z.string().url()),
   goalAmount: MoneySchema.optional(),
   pickupLocation: z.string(),
@@ -45,6 +53,13 @@ export const CreateFundraiserBody = z.object({
 export const UpdateFundraiserBody = z.object({
   name: z.string().min(1).max(255),
   description: z.string(),
+  venmoUsername: z
+    .string()
+    .optional()
+    .transform((value) =>
+      value ? (value.length === 0 ? undefined : value) : undefined
+    )
+    .pipe(z.string().min(5).max(30).optional()),
   goalAmount: MoneySchema.optional(),
   pickupLocation: z.string(),
   imageUrls: z.array(z.string().url()),

--- a/common/schemas/organization.ts
+++ b/common/schemas/organization.ts
@@ -12,8 +12,6 @@ export const BasicOrganizationSchema = z.object({
 export const CompleteOrganizationSchema = BasicOrganizationSchema.extend({
   websiteUrl: z.string().url().nullish(),
   instagramUsername: z.string().min(1).max(255).nullish(),
-  venmoUsername: z.string().min(1).max(255).nullish(),
-  venmoForwardingVerified: z.boolean(),
 
   admins: z.array(UserSchema),
 });
@@ -38,13 +36,6 @@ export const CreateOrganizationBody = z.object({
       value ? (value.length === 0 ? undefined : value) : undefined
     )
     .pipe(z.string().min(1).max(30).optional()),
-  venmoUsername: z
-    .string()
-    .optional()
-    .transform((value) =>
-      value ? (value.length === 0 ? undefined : value) : undefined
-    )
-    .pipe(z.string().min(5).max(30).optional()),
   addedAdminsIds: z.array(z.string().uuid()),
 });
 
@@ -66,12 +57,5 @@ export const UpdateOrganizationBody = z.object({
       value ? (value.length === 0 ? undefined : value) : undefined
     )
     .pipe(z.string().min(1).max(30).optional()),
-  venmoUsername: z
-    .string()
-    .optional()
-    .transform((value) =>
-      value ? (value.length === 0 ? undefined : value) : undefined
-    )
-    .pipe(z.string().min(5).max(30).optional()),
   addedAdminsIds: z.array(z.string().uuid()), // appends additional admin ids, doesn't replace original
 });

--- a/frontend/src/app/seller/org/create/components/CreateOrganizationForm.tsx
+++ b/frontend/src/app/seller/org/create/components/CreateOrganizationForm.tsx
@@ -21,7 +21,6 @@ export function CreateOrganizationForm({ token }: { token: string }) {
     logoUrl: undefined, // temporarily undefined because form doesn't populate these values
     websiteUrl: "",
     instagramUsername: "",
-    venmoUsername: undefined, // temporarily undefined because form doesn't populate these values
     addedAdminsIds: [],
   });
 

--- a/frontend/src/app/seller/org/create/components/ReviewOrganizationForm.tsx
+++ b/frontend/src/app/seller/org/create/components/ReviewOrganizationForm.tsx
@@ -48,11 +48,6 @@ export function ReviewOrganizationForm({
               Instagram Username: <b>@{formData.instagramUsername}</b>
             </p>
           )}
-          {formData.venmoUsername && (
-            <p>
-              Venmo Username: <b>@{formData.venmoUsername}</b>
-            </p>
-          )}
         </div>
         {admins.length > 0 && (
           <div className="mt-4 space-y-2">

--- a/frontend/src/components/custom/EditOrgInfoDialog.tsx
+++ b/frontend/src/components/custom/EditOrgInfoDialog.tsx
@@ -61,7 +61,6 @@ export function EditOrgInfoDialog({
       logoUrl: data.logoUrl ?? undefined, // Keep this in the form values but don't render the field
       websiteUrl: data.websiteUrl ?? "",
       instagramUsername: data.instagramUsername ?? "",
-      venmoUsername: data.venmoUsername ?? "",
       addedAdminsIds: [], // This will be populated with the IDs of additional admins
     },
     resetOptions: {
@@ -215,19 +214,6 @@ export function EditOrgInfoDialog({
                     <FormLabel>Instagram Username (optional)</FormLabel>
                     <FormControl>
                       <Input placeholder="username (without @)" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="venmoUsername"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Venmo Username (optional)</FormLabel>
-                    <FormControl>
-                      <Input placeholder="venmo-username" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>


### PR DESCRIPTION
As part of the Venmo integration feature, I am moving the Venmo username to be associated with a fundraiser and not an organization.

This PR drops the Venmo info (venmo_username, venmo_forwarding_verified) from the organization table and adds the Venmo info (venmo_username) to the fundraiser table. 

This PR also updates the zod models to reflect those changes.