### PR TITLE
Added attributes to cached analytics data

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "express": "^4.21.2",
     "form-data": "^4.0.2",
     "mailgun.js": "^12.0.1",
+    "memjs": "^1.3.2",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/backend/src/api/fundraiser/fundraiser.services.ts
+++ b/backend/src/api/fundraiser/fundraiser.services.ts
@@ -1,239 +1,246 @@
 import { prisma } from "../../utils/prisma";
 import {
-  CreateFundraiserBody,
-  UpdateFundraiserBody,
-  CreateFundraiserItemBody,
-  UpdateFundraiserItemBody,
-  CreateAnnouncementBody,
+	CreateFundraiserBody,
+	UpdateFundraiserBody,
+	CreateFundraiserItemBody,
+	UpdateFundraiserItemBody,
+	CreateAnnouncementBody,
 } from "common";
 import { z } from "zod";
 import memclient from "../../utils/memjs";
 
 export const getFundraiser = async (fundraiserId: string) => {
-  const fundraiser = await prisma.fundraiser.findUnique({
-    where: {
-      id: fundraiserId,
-    },
-    include: {
-      organization: {
-        include: {
-          admins: {
-            select: {
-              id: true,
-            },
-          },
-        },
-      },
-      announcements: {
-        orderBy: {
-          createdAt: "desc",
-        },
-      },
-    },
-  });
+	const fundraiser = await prisma.fundraiser.findUnique({
+		where: {
+			id: fundraiserId,
+		},
+		include: {
+			organization: {
+				include: {
+					admins: {
+						select: {
+							id: true,
+						},
+					},
+				},
+			},
+			announcements: {
+				orderBy: {
+					createdAt: "desc",
+				},
+			},
+		},
+	});
 
-  return fundraiser;
+	return fundraiser;
 };
 
 export const getFundraiserItems = async (fundraiserId: string) => {
-  const items = await prisma.item.findMany({
-    where: {
-      fundraiserId,
-    },
-    orderBy: {
-      createdAt: "asc",
-    },
-  });
+	const items = await prisma.item.findMany({
+		where: {
+			fundraiserId,
+		},
+		orderBy: {
+			createdAt: "asc",
+		},
+	});
 
-  return items;
+	return items;
 };
 
 export const getFundraiserOrders = async (fundraiserId: string) => {
-  const orders = await prisma.order.findMany({
-    where: {
-      fundraiserId,
-    },
-    include: {
-      buyer: true,
-      fundraiser: {
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          goalAmount: true,
-          imageUrls: true,
-          pickupLocation: true,
-          buyingStartsAt: true,
-          buyingEndsAt: true,
-          pickupStartsAt: true,
-          pickupEndsAt: true,
-          organization: {
-            select: {
-              id: true,
-              name: true,
-              description: true,
-              authorized: true,
-              logoUrl: true,
-            },
-          },
-        },
-      },
-      items: {
-        select: { quantity: true, item: true },
-      },
-    },
-    orderBy: {
-      createdAt: "desc",
-    },
-  });
+	const orders = await prisma.order.findMany({
+		where: {
+			fundraiserId,
+		},
+		include: {
+			buyer: true,
+			fundraiser: {
+				select: {
+					id: true,
+					name: true,
+					description: true,
+					goalAmount: true,
+					imageUrls: true,
+					pickupLocation: true,
+					buyingStartsAt: true,
+					buyingEndsAt: true,
+					pickupStartsAt: true,
+					pickupEndsAt: true,
+					organization: {
+						select: {
+							id: true,
+							name: true,
+							description: true,
+							authorized: true,
+							logoUrl: true,
+						},
+					},
+				},
+			},
+			items: {
+				select: { quantity: true, item: true },
+			},
+		},
+		orderBy: {
+			createdAt: "desc",
+		},
+	});
 
-  return orders;
+	return orders;
 };
 
 export const getAllFundraisers = async () => {
-  const fundraisers = await prisma.fundraiser.findMany({
-    include: {
-      organization: true,
-    },
-    orderBy: {
-      createdAt: "desc",
-    },
-  });
+	const fundraisers = await prisma.fundraiser.findMany({
+		include: {
+			organization: true,
+		},
+		orderBy: {
+			createdAt: "desc",
+		},
+	});
 
-  return fundraisers;
+	return fundraisers;
 };
 
 export const createFundraiser = async (
-  fundraiserBody: z.infer<typeof CreateFundraiserBody>
+	fundraiserBody: z.infer<typeof CreateFundraiserBody>
 ) => {
-  const fundraiser = await prisma.fundraiser.create({
-    data: {
-      name: fundraiserBody.name,
-      description: fundraiserBody.description,
-      venmoUsername: fundraiserBody.venmoUsername,
-      goalAmount: fundraiserBody.goalAmount,
-      pickupLocation: fundraiserBody.pickupLocation,
-      imageUrls: fundraiserBody.imageUrls,
-      buyingStartsAt: fundraiserBody.buyingStartsAt,
-      buyingEndsAt: fundraiserBody.buyingEndsAt,
-      pickupStartsAt: fundraiserBody.pickupStartsAt,
-      pickupEndsAt: fundraiserBody.pickupEndsAt,
-      organization: {
-        connect: {
-          id: fundraiserBody.organizationId,
-        },
-      },
-    },
-    include: {
-      organization: true,
-    },
-  });
+	const fundraiser = await prisma.fundraiser.create({
+		data: {
+			name: fundraiserBody.name,
+			description: fundraiserBody.description,
+			venmoUsername: fundraiserBody.venmoUsername,
+			goalAmount: fundraiserBody.goalAmount,
+			pickupLocation: fundraiserBody.pickupLocation,
+			imageUrls: fundraiserBody.imageUrls,
+			buyingStartsAt: fundraiserBody.buyingStartsAt,
+			buyingEndsAt: fundraiserBody.buyingEndsAt,
+			pickupStartsAt: fundraiserBody.pickupStartsAt,
+			pickupEndsAt: fundraiserBody.pickupEndsAt,
+			organization: {
+				connect: {
+					id: fundraiserBody.organizationId,
+				},
+			},
+		},
+		include: {
+			organization: true,
+		},
+	});
 
-  return fundraiser;
+	return fundraiser;
 };
 
 export const updateFundraiser = async (
-  fundraiserBody: z.infer<typeof UpdateFundraiserBody> & {
-    fundraiserId: string;
-  }
+	fundraiserBody: z.infer<typeof UpdateFundraiserBody> & {
+		fundraiserId: string;
+	}
 ) => {
-  const fundraiser = await prisma.fundraiser.update({
-    where: {
-      id: fundraiserBody.fundraiserId,
-    },
-    data: {
-      name: fundraiserBody.name,
-      description: fundraiserBody.description,
-      venmoUsername: fundraiserBody.venmoUsername ?? null,
-      goalAmount: fundraiserBody.goalAmount ?? null,
-      pickupLocation: fundraiserBody.pickupLocation,
-      imageUrls: fundraiserBody.imageUrls,
-      buyingStartsAt: fundraiserBody.buyingStartsAt,
-      buyingEndsAt: fundraiserBody.buyingEndsAt,
-      pickupStartsAt: fundraiserBody.pickupStartsAt,
-      pickupEndsAt: fundraiserBody.pickupEndsAt,
-    },
-    include: {
-      organization: true,
-    },
-  });
+	const fundraiser = await prisma.fundraiser.update({
+		where: {
+			id: fundraiserBody.fundraiserId,
+		},
+		data: {
+			name: fundraiserBody.name,
+			description: fundraiserBody.description,
+			venmoUsername: fundraiserBody.venmoUsername ?? null,
+			goalAmount: fundraiserBody.goalAmount ?? null,
+			pickupLocation: fundraiserBody.pickupLocation,
+			imageUrls: fundraiserBody.imageUrls,
+			buyingStartsAt: fundraiserBody.buyingStartsAt,
+			buyingEndsAt: fundraiserBody.buyingEndsAt,
+			pickupStartsAt: fundraiserBody.pickupStartsAt,
+			pickupEndsAt: fundraiserBody.pickupEndsAt,
+		},
+		include: {
+			organization: true,
+		},
+	});
 
-  return fundraiser;
+	return fundraiser;
 };
 
 export const createFundraiserItem = async (
-  itemBody: z.infer<typeof CreateFundraiserItemBody> & { fundraiserId: string }
+	itemBody: z.infer<typeof CreateFundraiserItemBody> & { fundraiserId: string }
 ) => {
-  const item = await prisma.item.create({
-    data: {
-      name: itemBody.name,
-      description: itemBody.description,
-      price: itemBody.price,
-      imageUrl: itemBody.imageUrl,
-      fundraiser: {
-        connect: {
-          id: itemBody.fundraiserId,
-        },
-      },
-    },
-  });
+	const item = await prisma.item.create({
+		data: {
+			name: itemBody.name,
+			description: itemBody.description,
+			price: itemBody.price,
+			imageUrl: itemBody.imageUrl,
+			fundraiser: {
+				connect: {
+					id: itemBody.fundraiserId,
+				},
+			},
+		},
+	});
 
-  return item;
+	return item;
 };
 
 export const updateFundraiserItem = async (
-  itemBody: z.infer<typeof UpdateFundraiserItemBody> & { itemId: string }
+	itemBody: z.infer<typeof UpdateFundraiserItemBody> & { itemId: string }
 ) => {
-  const item = await prisma.item.update({
-    where: {
-      id: itemBody.itemId,
-    },
-    data: {
-      name: itemBody.name,
-      description: itemBody.description,
-      price: itemBody.price,
-      imageUrl: itemBody.imageUrl ?? null,
-      offsale: itemBody.offsale,
-    },
-  });
+	const item = await prisma.item.update({
+		where: {
+			id: itemBody.itemId,
+		},
+		data: {
+			name: itemBody.name,
+			description: itemBody.description,
+			price: itemBody.price,
+			imageUrl: itemBody.imageUrl ?? null,
+			offsale: itemBody.offsale,
+		},
+	});
 
-  return item;
+	return item;
 };
 
 export const createAnnouncement = async (
-  announcementBody: z.infer<typeof CreateAnnouncementBody> & {
-    fundraiserId: string;
-  }
+	announcementBody: z.infer<typeof CreateAnnouncementBody> & {
+		fundraiserId: string;
+	}
 ) => {
-  const announcement = await prisma.announcement.create({
-    data: {
-      message: announcementBody.message,
-      fundraiser: {
-        connect: {
-          id: announcementBody.fundraiserId,
-        },
-      },
-    },
-  });
+	const announcement = await prisma.announcement.create({
+		data: {
+			message: announcementBody.message,
+			fundraiser: {
+				connect: {
+					id: announcementBody.fundraiserId,
+				},
+			},
+		},
+	});
 
-  return announcement;
+	return announcement;
 };
 
 export const deleteAnnouncement = async (announcementId: string) => {
-  const announcement = await prisma.announcement.delete({
-    where: {
-      id: announcementId,
-    },
-  });
+	const announcement = await prisma.announcement.delete({
+		where: {
+			id: announcementId,
+		},
+	});
 
-  return announcement;
+	return announcement;
 };
 
 export interface FundraiserAnalytics {
-  total_revenue: number;
-  total_orders: number;
-  orders_picked_up: number;
-  items: Record<string, number>;
+	total_revenue: number;
+	total_orders: number;
+	orders_picked_up: number;
+	items: Record<string, number>; // units sold for each item
+	pending_orders: number;
+	profit: number;
+	goal_amount: number;
+	sale_data: Record<string, number>; // orders sold on a particular day
+	revenue_data: Record<string, number>; // revenue earned on a particular day
+	start_date: string;
+	end_date: string;
 }
 
 /**
@@ -242,51 +249,73 @@ export interface FundraiserAnalytics {
  * @returns Promise<FundraiserAnalytics> - Analytics data including revenue, orders, and item statistics
  */
 export const calculateAndCacheFundraiserAnalytics = async (
-  fundraiserId: string
+	fundraiserId: string
 ) => {
-  const orders = await prisma.order.findMany({
-    where: { fundraiserId },
-    include: {
-      items: {
-        select: {
-          quantity: true,
-          item: { select: { name: true, price: true } },
-        },
-      },
-    },
-  });
+	const [orders, fundraiser] = await Promise.all([
+		prisma.order.findMany({
+			where: { fundraiserId },
+			include: {
+				items: {
+					select: {
+						quantity: true,
+						item: { select: { name: true, price: true } },
+					},
+				},
+			},
+		}),
+		getFundraiser(fundraiserId),
+	]);
 
-  const analytics: FundraiserAnalytics = {
-    total_revenue: 0,
-    total_orders: orders.length,
-    orders_picked_up: 0,
-    items: {},
-  };
+	const analytics: FundraiserAnalytics = {
+		total_revenue: 0,
+		total_orders: orders.length,
+		orders_picked_up: 0,
+		items: {},
+		pending_orders: 0,
+		profit: 0,
+		goal_amount: Number(fundraiser?.goalAmount) ?? 0,
+		sale_data: {},
+		revenue_data: {},
+		start_date: fundraiser?.buyingStartsAt?.toISOString() ?? "",
+		end_date: fundraiser?.buyingEndsAt?.toISOString() ?? "",
+	};
 
-  orders.forEach((order) => {
-    let orderTotal = 0;
+	orders.forEach((order) => {
+		let orderTotal = 0;
 
-    order.items.forEach((orderItem) => {
-      const itemTotal = orderItem.quantity * Number(orderItem.item.price);
-      orderTotal += itemTotal;
-      analytics.items[orderItem.item.name] =
-        (analytics.items[orderItem.item.name] || 0) + orderItem.quantity;
-    });
+		order.items.forEach((orderItem) => {
+			const itemTotal = orderItem.quantity * Number(orderItem.item.price);
+			orderTotal += itemTotal;
+			analytics.items[orderItem.item.name] =
+				(analytics.items[orderItem.item.name] || 0) + orderItem.quantity;
+		});
 
-    analytics.total_revenue += orderTotal;
+		analytics.total_revenue += orderTotal;
 
-    if (order.pickedUp) {
-      analytics.orders_picked_up++;
-    }
-  });
+		if (order.pickedUp) {
+			analytics.orders_picked_up++;
+		} else {
+			analytics.pending_orders++;
+		}
 
-  const cacheKey = `fundraiser_analytics_${fundraiserId}`;
-  try {
-    await memclient.set(cacheKey, JSON.stringify(analytics), { expires: 7200 }); // Tentative expiration of 2 hrs
-  } catch (error) {
-    console.error("Failed to cache analytics:", error);
-  }
-  return analytics;
+		// Track sales by date
+		const orderDate = order.createdAt.toISOString().split("T")[0]; // Only keep the YYYY-MM-DD portion
+		analytics.sale_data[orderDate] = (analytics.sale_data[orderDate] || 0) + 1;
+
+		// Track revenue by date
+		analytics.revenue_data[orderDate] =
+			(analytics.revenue_data[orderDate] || 0) + orderTotal;
+	});
+
+	analytics.profit = Math.round(analytics.total_revenue * 0.2 * 100) / 100; // Assuming 20% profit, rounded to 2 decimals
+
+	const cacheKey = `fundraiser_analytics_${fundraiserId}`;
+	try {
+		await memclient.set(cacheKey, JSON.stringify(analytics), { expires: 7200 }); // Tentative expiration of 2 hrs
+	} catch (error) {
+		console.error("Failed to cache analytics:", error);
+	}
+	return analytics;
 };
 
 /**
@@ -295,19 +324,20 @@ export const calculateAndCacheFundraiserAnalytics = async (
  * @returns Promise<FundraiserAnalytics> - Analytics data from cache or freshly calculated
  */
 export const getFundraiserAnalytics = async (fundraiserId: string) => {
-  // Fundraiser specific id to access the cache
-  const cacheKey = `fundraiser_analytics_${fundraiserId}`;
+	// Fundraiser specific id to access the cache
+	const cacheKey = `fundraiser_analytics_${fundraiserId}`;
 
-  try {
-    const cached = await memclient.get(cacheKey);
-    if (cached.value) {
-      console.log("This data is in cache");
-      return JSON.parse(cached.value.toString());
-    }
-  } catch (error) {
-    console.error("Failed to get cached analytics:", error);
-  }
-  return await calculateAndCacheFundraiserAnalytics(fundraiserId);
+	try {
+		const cached = await memclient.get(cacheKey);
+		if (cached.value) {
+			console.log("This data is in cache");
+			return JSON.parse(cached.value.toString());
+		}
+		console.log("This data is NOT in cache");
+	} catch (error) {
+		console.error("Failed to get cached analytics:", error);
+	}
+	return await calculateAndCacheFundraiserAnalytics(fundraiserId);
 };
 
 /**
@@ -317,12 +347,12 @@ export const getFundraiserAnalytics = async (fundraiserId: string) => {
  */
 // This is tentative for now, need to decide when the cache will be invalidated for the fundraiser
 export const invalidateFundraiserAnalyticsCache = async (
-  fundraiserId: string
+	fundraiserId: string
 ) => {
-  const cacheKey = `fundraiser_analytics_${fundraiserId}`;
-  try {
-    await memclient.delete(cacheKey);
-  } catch (error) {
-    console.error("Failed to invalidate analytics cache:", error);
-  }
+	const cacheKey = `fundraiser_analytics_${fundraiserId}`;
+	try {
+		await memclient.delete(cacheKey);
+	} catch (error) {
+		console.error("Failed to invalidate analytics cache:", error);
+	}
 };

--- a/backend/src/api/fundraiser/fundraiser.services.ts
+++ b/backend/src/api/fundraiser/fundraiser.services.ts
@@ -1,246 +1,246 @@
 import { prisma } from "../../utils/prisma";
 import {
-	CreateFundraiserBody,
-	UpdateFundraiserBody,
-	CreateFundraiserItemBody,
-	UpdateFundraiserItemBody,
-	CreateAnnouncementBody,
+  CreateFundraiserBody,
+  UpdateFundraiserBody,
+  CreateFundraiserItemBody,
+  UpdateFundraiserItemBody,
+  CreateAnnouncementBody,
 } from "common";
 import { z } from "zod";
 import memclient from "../../utils/memjs";
 
 export const getFundraiser = async (fundraiserId: string) => {
-	const fundraiser = await prisma.fundraiser.findUnique({
-		where: {
-			id: fundraiserId,
-		},
-		include: {
-			organization: {
-				include: {
-					admins: {
-						select: {
-							id: true,
-						},
-					},
-				},
-			},
-			announcements: {
-				orderBy: {
-					createdAt: "desc",
-				},
-			},
-		},
-	});
+  const fundraiser = await prisma.fundraiser.findUnique({
+    where: {
+      id: fundraiserId,
+    },
+    include: {
+      organization: {
+        include: {
+          admins: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      },
+      announcements: {
+        orderBy: {
+          createdAt: "desc",
+        },
+      },
+    },
+  });
 
-	return fundraiser;
+  return fundraiser;
 };
 
 export const getFundraiserItems = async (fundraiserId: string) => {
-	const items = await prisma.item.findMany({
-		where: {
-			fundraiserId,
-		},
-		orderBy: {
-			createdAt: "asc",
-		},
-	});
+  const items = await prisma.item.findMany({
+    where: {
+      fundraiserId,
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
 
-	return items;
+  return items;
 };
 
 export const getFundraiserOrders = async (fundraiserId: string) => {
-	const orders = await prisma.order.findMany({
-		where: {
-			fundraiserId,
-		},
-		include: {
-			buyer: true,
-			fundraiser: {
-				select: {
-					id: true,
-					name: true,
-					description: true,
-					goalAmount: true,
-					imageUrls: true,
-					pickupLocation: true,
-					buyingStartsAt: true,
-					buyingEndsAt: true,
-					pickupStartsAt: true,
-					pickupEndsAt: true,
-					organization: {
-						select: {
-							id: true,
-							name: true,
-							description: true,
-							authorized: true,
-							logoUrl: true,
-						},
-					},
-				},
-			},
-			items: {
-				select: { quantity: true, item: true },
-			},
-		},
-		orderBy: {
-			createdAt: "desc",
-		},
-	});
+  const orders = await prisma.order.findMany({
+    where: {
+      fundraiserId,
+    },
+    include: {
+      buyer: true,
+      fundraiser: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          goalAmount: true,
+          imageUrls: true,
+          pickupLocation: true,
+          buyingStartsAt: true,
+          buyingEndsAt: true,
+          pickupStartsAt: true,
+          pickupEndsAt: true,
+          organization: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              authorized: true,
+              logoUrl: true,
+            },
+          },
+        },
+      },
+      items: {
+        select: { quantity: true, item: true },
+      },
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
 
-	return orders;
+  return orders;
 };
 
 export const getAllFundraisers = async () => {
-	const fundraisers = await prisma.fundraiser.findMany({
-		include: {
-			organization: true,
-		},
-		orderBy: {
-			createdAt: "desc",
-		},
-	});
+  const fundraisers = await prisma.fundraiser.findMany({
+    include: {
+      organization: true,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
 
-	return fundraisers;
+  return fundraisers;
 };
 
 export const createFundraiser = async (
-	fundraiserBody: z.infer<typeof CreateFundraiserBody>
+  fundraiserBody: z.infer<typeof CreateFundraiserBody>
 ) => {
-	const fundraiser = await prisma.fundraiser.create({
-		data: {
-			name: fundraiserBody.name,
-			description: fundraiserBody.description,
-			venmoUsername: fundraiserBody.venmoUsername,
-			goalAmount: fundraiserBody.goalAmount,
-			pickupLocation: fundraiserBody.pickupLocation,
-			imageUrls: fundraiserBody.imageUrls,
-			buyingStartsAt: fundraiserBody.buyingStartsAt,
-			buyingEndsAt: fundraiserBody.buyingEndsAt,
-			pickupStartsAt: fundraiserBody.pickupStartsAt,
-			pickupEndsAt: fundraiserBody.pickupEndsAt,
-			organization: {
-				connect: {
-					id: fundraiserBody.organizationId,
-				},
-			},
-		},
-		include: {
-			organization: true,
-		},
-	});
+  const fundraiser = await prisma.fundraiser.create({
+    data: {
+      name: fundraiserBody.name,
+      description: fundraiserBody.description,
+      venmoUsername: fundraiserBody.venmoUsername,
+      goalAmount: fundraiserBody.goalAmount,
+      pickupLocation: fundraiserBody.pickupLocation,
+      imageUrls: fundraiserBody.imageUrls,
+      buyingStartsAt: fundraiserBody.buyingStartsAt,
+      buyingEndsAt: fundraiserBody.buyingEndsAt,
+      pickupStartsAt: fundraiserBody.pickupStartsAt,
+      pickupEndsAt: fundraiserBody.pickupEndsAt,
+      organization: {
+        connect: {
+          id: fundraiserBody.organizationId,
+        },
+      },
+    },
+    include: {
+      organization: true,
+    },
+  });
 
-	return fundraiser;
+  return fundraiser;
 };
 
 export const updateFundraiser = async (
-	fundraiserBody: z.infer<typeof UpdateFundraiserBody> & {
-		fundraiserId: string;
-	}
+  fundraiserBody: z.infer<typeof UpdateFundraiserBody> & {
+    fundraiserId: string;
+  }
 ) => {
-	const fundraiser = await prisma.fundraiser.update({
-		where: {
-			id: fundraiserBody.fundraiserId,
-		},
-		data: {
-			name: fundraiserBody.name,
-			description: fundraiserBody.description,
-			venmoUsername: fundraiserBody.venmoUsername ?? null,
-			goalAmount: fundraiserBody.goalAmount ?? null,
-			pickupLocation: fundraiserBody.pickupLocation,
-			imageUrls: fundraiserBody.imageUrls,
-			buyingStartsAt: fundraiserBody.buyingStartsAt,
-			buyingEndsAt: fundraiserBody.buyingEndsAt,
-			pickupStartsAt: fundraiserBody.pickupStartsAt,
-			pickupEndsAt: fundraiserBody.pickupEndsAt,
-		},
-		include: {
-			organization: true,
-		},
-	});
+  const fundraiser = await prisma.fundraiser.update({
+    where: {
+      id: fundraiserBody.fundraiserId,
+    },
+    data: {
+      name: fundraiserBody.name,
+      description: fundraiserBody.description,
+      venmoUsername: fundraiserBody.venmoUsername ?? null,
+      goalAmount: fundraiserBody.goalAmount ?? null,
+      pickupLocation: fundraiserBody.pickupLocation,
+      imageUrls: fundraiserBody.imageUrls,
+      buyingStartsAt: fundraiserBody.buyingStartsAt,
+      buyingEndsAt: fundraiserBody.buyingEndsAt,
+      pickupStartsAt: fundraiserBody.pickupStartsAt,
+      pickupEndsAt: fundraiserBody.pickupEndsAt,
+    },
+    include: {
+      organization: true,
+    },
+  });
 
-	return fundraiser;
+  return fundraiser;
 };
 
 export const createFundraiserItem = async (
-	itemBody: z.infer<typeof CreateFundraiserItemBody> & { fundraiserId: string }
+  itemBody: z.infer<typeof CreateFundraiserItemBody> & { fundraiserId: string }
 ) => {
-	const item = await prisma.item.create({
-		data: {
-			name: itemBody.name,
-			description: itemBody.description,
-			price: itemBody.price,
-			imageUrl: itemBody.imageUrl,
-			fundraiser: {
-				connect: {
-					id: itemBody.fundraiserId,
-				},
-			},
-		},
-	});
+  const item = await prisma.item.create({
+    data: {
+      name: itemBody.name,
+      description: itemBody.description,
+      price: itemBody.price,
+      imageUrl: itemBody.imageUrl,
+      fundraiser: {
+        connect: {
+          id: itemBody.fundraiserId,
+        },
+      },
+    },
+  });
 
-	return item;
+  return item;
 };
 
 export const updateFundraiserItem = async (
-	itemBody: z.infer<typeof UpdateFundraiserItemBody> & { itemId: string }
+  itemBody: z.infer<typeof UpdateFundraiserItemBody> & { itemId: string }
 ) => {
-	const item = await prisma.item.update({
-		where: {
-			id: itemBody.itemId,
-		},
-		data: {
-			name: itemBody.name,
-			description: itemBody.description,
-			price: itemBody.price,
-			imageUrl: itemBody.imageUrl ?? null,
-			offsale: itemBody.offsale,
-		},
-	});
+  const item = await prisma.item.update({
+    where: {
+      id: itemBody.itemId,
+    },
+    data: {
+      name: itemBody.name,
+      description: itemBody.description,
+      price: itemBody.price,
+      imageUrl: itemBody.imageUrl ?? null,
+      offsale: itemBody.offsale,
+    },
+  });
 
-	return item;
+  return item;
 };
 
 export const createAnnouncement = async (
-	announcementBody: z.infer<typeof CreateAnnouncementBody> & {
-		fundraiserId: string;
-	}
+  announcementBody: z.infer<typeof CreateAnnouncementBody> & {
+    fundraiserId: string;
+  }
 ) => {
-	const announcement = await prisma.announcement.create({
-		data: {
-			message: announcementBody.message,
-			fundraiser: {
-				connect: {
-					id: announcementBody.fundraiserId,
-				},
-			},
-		},
-	});
+  const announcement = await prisma.announcement.create({
+    data: {
+      message: announcementBody.message,
+      fundraiser: {
+        connect: {
+          id: announcementBody.fundraiserId,
+        },
+      },
+    },
+  });
 
-	return announcement;
+  return announcement;
 };
 
 export const deleteAnnouncement = async (announcementId: string) => {
-	const announcement = await prisma.announcement.delete({
-		where: {
-			id: announcementId,
-		},
-	});
+  const announcement = await prisma.announcement.delete({
+    where: {
+      id: announcementId,
+    },
+  });
 
-	return announcement;
+  return announcement;
 };
 
 export interface FundraiserAnalytics {
-	total_revenue: number;
-	total_orders: number;
-	orders_picked_up: number;
-	items: Record<string, number>; // units sold for each item
-	pending_orders: number;
-	profit: number;
-	goal_amount: number;
-	sale_data: Record<string, number>; // orders sold on a particular day
-	revenue_data: Record<string, number>; // revenue earned on a particular day
-	start_date: string;
-	end_date: string;
+  total_revenue: number;
+  total_orders: number;
+  orders_picked_up: number;
+  items: Record<string, number>; // units sold for each item
+  pending_orders: number;
+  profit: number;
+  goal_amount: number;
+  sale_data: Record<string, number>; // orders sold on a particular day
+  revenue_data: Record<string, number>; // revenue earned on a particular day
+  start_date: string;
+  end_date: string;
 }
 
 /**
@@ -249,73 +249,73 @@ export interface FundraiserAnalytics {
  * @returns Promise<FundraiserAnalytics> - Analytics data including revenue, orders, and item statistics
  */
 export const calculateAndCacheFundraiserAnalytics = async (
-	fundraiserId: string
+  fundraiserId: string
 ) => {
-	const [orders, fundraiser] = await Promise.all([
-		prisma.order.findMany({
-			where: { fundraiserId },
-			include: {
-				items: {
-					select: {
-						quantity: true,
-						item: { select: { name: true, price: true } },
-					},
-				},
-			},
-		}),
-		getFundraiser(fundraiserId),
-	]);
+  const [orders, fundraiser] = await Promise.all([
+    prisma.order.findMany({
+      where: { fundraiserId },
+      include: {
+        items: {
+          select: {
+            quantity: true,
+            item: { select: { name: true, price: true } },
+          },
+        },
+      },
+    }),
+    getFundraiser(fundraiserId),
+  ]);
 
-	const analytics: FundraiserAnalytics = {
-		total_revenue: 0,
-		total_orders: orders.length,
-		orders_picked_up: 0,
-		items: {},
-		pending_orders: 0,
-		profit: 0,
-		goal_amount: Number(fundraiser?.goalAmount) ?? 0,
-		sale_data: {},
-		revenue_data: {},
-		start_date: fundraiser?.buyingStartsAt?.toISOString() ?? "",
-		end_date: fundraiser?.buyingEndsAt?.toISOString() ?? "",
-	};
+  const analytics: FundraiserAnalytics = {
+    total_revenue: 0,
+    total_orders: orders.length,
+    orders_picked_up: 0,
+    items: {},
+    pending_orders: 0,
+    profit: 0,
+    goal_amount: Number(fundraiser?.goalAmount) ?? 0,
+    sale_data: {},
+    revenue_data: {},
+    start_date: fundraiser?.buyingStartsAt?.toISOString() ?? "",
+    end_date: fundraiser?.buyingEndsAt?.toISOString() ?? "",
+  };
 
-	orders.forEach((order) => {
-		let orderTotal = 0;
+  orders.forEach((order) => {
+    let orderTotal = 0;
 
-		order.items.forEach((orderItem) => {
-			const itemTotal = orderItem.quantity * Number(orderItem.item.price);
-			orderTotal += itemTotal;
-			analytics.items[orderItem.item.name] =
-				(analytics.items[orderItem.item.name] || 0) + orderItem.quantity;
-		});
+    order.items.forEach((orderItem) => {
+      const itemTotal = orderItem.quantity * Number(orderItem.item.price);
+      orderTotal += itemTotal;
+      analytics.items[orderItem.item.name] =
+        (analytics.items[orderItem.item.name] || 0) + orderItem.quantity;
+    });
 
-		analytics.total_revenue += orderTotal;
+    analytics.total_revenue += orderTotal;
 
-		if (order.pickedUp) {
-			analytics.orders_picked_up++;
-		} else {
-			analytics.pending_orders++;
-		}
+    if (order.pickedUp) {
+      analytics.orders_picked_up++;
+    } else {
+      analytics.pending_orders++;
+    }
 
-		// Track sales by date
-		const orderDate = order.createdAt.toISOString().split("T")[0]; // Only keep the YYYY-MM-DD portion
-		analytics.sale_data[orderDate] = (analytics.sale_data[orderDate] || 0) + 1;
+    // Track sales by date
+    const orderDate = order.createdAt.toISOString().split("T")[0]; // Only keep the YYYY-MM-DD portion
+    analytics.sale_data[orderDate] = (analytics.sale_data[orderDate] || 0) + 1;
 
-		// Track revenue by date
-		analytics.revenue_data[orderDate] =
-			(analytics.revenue_data[orderDate] || 0) + orderTotal;
-	});
+    // Track revenue by date
+    analytics.revenue_data[orderDate] =
+      (analytics.revenue_data[orderDate] || 0) + orderTotal;
+  });
 
-	analytics.profit = Math.round(analytics.total_revenue * 0.2 * 100) / 100; // Assuming 20% profit, rounded to 2 decimals
+  analytics.profit = Math.round(analytics.total_revenue * 0.2 * 100) / 100; // Assuming 20% profit, rounded to 2 decimals
 
-	const cacheKey = `fundraiser_analytics_${fundraiserId}`;
-	try {
-		await memclient.set(cacheKey, JSON.stringify(analytics), { expires: 7200 }); // Tentative expiration of 2 hrs
-	} catch (error) {
-		console.error("Failed to cache analytics:", error);
-	}
-	return analytics;
+  const cacheKey = `fundraiser_analytics_${fundraiserId}`;
+  try {
+    await memclient.set(cacheKey, JSON.stringify(analytics), { expires: 7200 }); // Tentative expiration of 2 hrs
+  } catch (error) {
+    console.error("Failed to cache analytics:", error);
+  }
+  return analytics;
 };
 
 /**
@@ -324,20 +324,20 @@ export const calculateAndCacheFundraiserAnalytics = async (
  * @returns Promise<FundraiserAnalytics> - Analytics data from cache or freshly calculated
  */
 export const getFundraiserAnalytics = async (fundraiserId: string) => {
-	// Fundraiser specific id to access the cache
-	const cacheKey = `fundraiser_analytics_${fundraiserId}`;
+  // Fundraiser specific id to access the cache
+  const cacheKey = `fundraiser_analytics_${fundraiserId}`;
 
-	try {
-		const cached = await memclient.get(cacheKey);
-		if (cached.value) {
-			console.log("This data is in cache");
-			return JSON.parse(cached.value.toString());
-		}
-		console.log("This data is NOT in cache");
-	} catch (error) {
-		console.error("Failed to get cached analytics:", error);
-	}
-	return await calculateAndCacheFundraiserAnalytics(fundraiserId);
+  try {
+    const cached = await memclient.get(cacheKey);
+    if (cached.value) {
+      console.log("This data is in cache");
+      return JSON.parse(cached.value.toString());
+    }
+    console.log("This data is NOT in cache");
+  } catch (error) {
+    console.error("Failed to get cached analytics:", error);
+  }
+  return await calculateAndCacheFundraiserAnalytics(fundraiserId);
 };
 
 /**
@@ -347,12 +347,12 @@ export const getFundraiserAnalytics = async (fundraiserId: string) => {
  */
 // This is tentative for now, need to decide when the cache will be invalidated for the fundraiser
 export const invalidateFundraiserAnalyticsCache = async (
-	fundraiserId: string
+  fundraiserId: string
 ) => {
-	const cacheKey = `fundraiser_analytics_${fundraiserId}`;
-	try {
-		await memclient.delete(cacheKey);
-	} catch (error) {
-		console.error("Failed to invalidate analytics cache:", error);
-	}
+  const cacheKey = `fundraiser_analytics_${fundraiserId}`;
+  try {
+    await memclient.delete(cacheKey);
+  } catch (error) {
+    console.error("Failed to invalidate analytics cache:", error);
+  }
 };

--- a/backend/src/api/order/order.services.ts
+++ b/backend/src/api/order/order.services.ts
@@ -1,165 +1,172 @@
 import { prisma } from "../../utils/prisma";
 import { CreateOrderBody } from "common";
 import { z } from "zod";
+import { invalidateFundraiserAnalyticsCache } from "../fundraiser/fundraiser.services";
 
 export const getOrder = async (orderId: string) => {
-  const order = await prisma.order.findUnique({
-    where: { id: orderId },
-    include: {
-      buyer: true,
-      fundraiser: {
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          goalAmount: true,
-          imageUrls: true,
-          pickupLocation: true,
-          buyingStartsAt: true,
-          buyingEndsAt: true,
-          pickupStartsAt: true,
-          pickupEndsAt: true,
-          organization: {
-            select: {
-              id: true,
-              name: true,
-              description: true,
-              authorized: true,
-              logoUrl: true,
-              admins: {
-                select: { id: true },
-              },
-            },
-          },
-        },
-      },
-      items: {
-        select: { quantity: true, item: true },
-      },
-    },
-  });
+	const order = await prisma.order.findUnique({
+		where: { id: orderId },
+		include: {
+			buyer: true,
+			fundraiser: {
+				select: {
+					id: true,
+					name: true,
+					description: true,
+					goalAmount: true,
+					imageUrls: true,
+					pickupLocation: true,
+					buyingStartsAt: true,
+					buyingEndsAt: true,
+					pickupStartsAt: true,
+					pickupEndsAt: true,
+					organization: {
+						select: {
+							id: true,
+							name: true,
+							description: true,
+							authorized: true,
+							logoUrl: true,
+							admins: {
+								select: { id: true },
+							},
+						},
+					},
+				},
+			},
+			items: {
+				select: { quantity: true, item: true },
+			},
+		},
+	});
 
-  return order;
+	return order;
 };
 
 export const createOrder = async (
-  orderBody: z.infer<typeof CreateOrderBody> & { buyerId: string }
+	orderBody: z.infer<typeof CreateOrderBody> & { buyerId: string }
 ) => {
-  const order = await prisma.order.create({
-    data: {
-      paymentMethod: orderBody.payment_method,
-      paymentStatus:
-        orderBody.payment_method === "VENMO" ? "PENDING" : "UNVERIFIABLE",
-      buyer: { connect: { id: orderBody.buyerId } },
-      fundraiser: { connect: { id: orderBody.fundraiserId } },
-      items: {
-        create: orderBody.items.map((item) => ({
-          quantity: item.quantity,
-          item: { connect: { id: item.itemId } },
-        })),
-      },
-    },
-    include: {
-      buyer: true,
-      fundraiser: {
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          goalAmount: true,
-          imageUrls: true,
-          pickupLocation: true,
-          buyingStartsAt: true,
-          buyingEndsAt: true,
-          pickupStartsAt: true,
-          pickupEndsAt: true,
-          organization: {
-            select: {
-              id: true,
-              name: true,
-              description: true,
-              authorized: true,
-              logoUrl: true,
-            },
-          },
-        },
-      },
-    },
-  });
+	const order = await prisma.order.create({
+		data: {
+			paymentMethod: orderBody.payment_method,
+			paymentStatus:
+				orderBody.payment_method === "VENMO" ? "PENDING" : "UNVERIFIABLE",
+			buyer: { connect: { id: orderBody.buyerId } },
+			fundraiser: { connect: { id: orderBody.fundraiserId } },
+			items: {
+				create: orderBody.items.map((item) => ({
+					quantity: item.quantity,
+					item: { connect: { id: item.itemId } },
+				})),
+			},
+		},
+		include: {
+			buyer: true,
+			fundraiser: {
+				select: {
+					id: true,
+					name: true,
+					description: true,
+					goalAmount: true,
+					imageUrls: true,
+					pickupLocation: true,
+					buyingStartsAt: true,
+					buyingEndsAt: true,
+					pickupStartsAt: true,
+					pickupEndsAt: true,
+					organization: {
+						select: {
+							id: true,
+							name: true,
+							description: true,
+							authorized: true,
+							logoUrl: true,
+						},
+					},
+				},
+			},
+		},
+	});
 
-  return order;
+	// Invalidate analytics cache for the fundraiser when a new order is created
+	await invalidateFundraiserAnalyticsCache(orderBody.fundraiserId);
+
+	return order;
 };
 
 export const completeOrderPickup = async (orderId: string) => {
-  const order = await prisma.order.update({
-    where: { id: orderId },
-    data: {
-      pickedUp: true,
-    },
-    include: {
-      buyer: true,
-      fundraiser: {
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          goalAmount: true,
-          imageUrls: true,
-          pickupLocation: true,
-          buyingStartsAt: true,
-          buyingEndsAt: true,
-          pickupStartsAt: true,
-          pickupEndsAt: true,
-          organization: {
-            select: {
-              id: true,
-              name: true,
-              description: true,
-              authorized: true,
-              logoUrl: true,
-            },
-          },
-        },
-      },
-    },
-  });
+	const order = await prisma.order.update({
+		where: { id: orderId },
+		data: {
+			pickedUp: true,
+		},
+		include: {
+			buyer: true,
+			fundraiser: {
+				select: {
+					id: true,
+					name: true,
+					description: true,
+					goalAmount: true,
+					imageUrls: true,
+					pickupLocation: true,
+					buyingStartsAt: true,
+					buyingEndsAt: true,
+					pickupStartsAt: true,
+					pickupEndsAt: true,
+					organization: {
+						select: {
+							id: true,
+							name: true,
+							description: true,
+							authorized: true,
+							logoUrl: true,
+						},
+					},
+				},
+			},
+		},
+	});
 
-  return order;
+	// Invalidate analytics cache for the fundraiser when an order is picked up, so pending order and picked up order counts are not stale
+	await invalidateFundraiserAnalyticsCache(order.fundraiser.id);
+
+	return order;
 };
 
 export const confirmOrderPayment = async (orderId: string) => {
-  const order = await prisma.order.update({
-    where: { id: orderId },
-    data: {
-      paymentStatus: "CONFIRMED",
-    },
-    include: {
-      buyer: true,
-      fundraiser: {
-        select: {
-          id: true,
-          name: true,
-          description: true,
-          goalAmount: true,
-          imageUrls: true,
-          pickupLocation: true,
-          buyingStartsAt: true,
-          buyingEndsAt: true,
-          pickupStartsAt: true,
-          pickupEndsAt: true,
-          organization: {
-            select: {
-              id: true,
-              name: true,
-              description: true,
-              authorized: true,
-              logoUrl: true,
-            },
-          },
-        },
-      },
-    },
-  });
+	const order = await prisma.order.update({
+		where: { id: orderId },
+		data: {
+			paymentStatus: "CONFIRMED",
+		},
+		include: {
+			buyer: true,
+			fundraiser: {
+				select: {
+					id: true,
+					name: true,
+					description: true,
+					goalAmount: true,
+					imageUrls: true,
+					pickupLocation: true,
+					buyingStartsAt: true,
+					buyingEndsAt: true,
+					pickupStartsAt: true,
+					pickupEndsAt: true,
+					organization: {
+						select: {
+							id: true,
+							name: true,
+							description: true,
+							authorized: true,
+							logoUrl: true,
+						},
+					},
+				},
+			},
+		},
+	});
 
-  return order;
+	return order;
 };

--- a/backend/src/api/order/order.services.ts
+++ b/backend/src/api/order/order.services.ts
@@ -4,169 +4,169 @@ import { z } from "zod";
 import { invalidateFundraiserAnalyticsCache } from "../fundraiser/fundraiser.services";
 
 export const getOrder = async (orderId: string) => {
-	const order = await prisma.order.findUnique({
-		where: { id: orderId },
-		include: {
-			buyer: true,
-			fundraiser: {
-				select: {
-					id: true,
-					name: true,
-					description: true,
-					goalAmount: true,
-					imageUrls: true,
-					pickupLocation: true,
-					buyingStartsAt: true,
-					buyingEndsAt: true,
-					pickupStartsAt: true,
-					pickupEndsAt: true,
-					organization: {
-						select: {
-							id: true,
-							name: true,
-							description: true,
-							authorized: true,
-							logoUrl: true,
-							admins: {
-								select: { id: true },
-							},
-						},
-					},
-				},
-			},
-			items: {
-				select: { quantity: true, item: true },
-			},
-		},
-	});
+  const order = await prisma.order.findUnique({
+    where: { id: orderId },
+    include: {
+      buyer: true,
+      fundraiser: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          goalAmount: true,
+          imageUrls: true,
+          pickupLocation: true,
+          buyingStartsAt: true,
+          buyingEndsAt: true,
+          pickupStartsAt: true,
+          pickupEndsAt: true,
+          organization: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              authorized: true,
+              logoUrl: true,
+              admins: {
+                select: { id: true },
+              },
+            },
+          },
+        },
+      },
+      items: {
+        select: { quantity: true, item: true },
+      },
+    },
+  });
 
-	return order;
+  return order;
 };
 
 export const createOrder = async (
-	orderBody: z.infer<typeof CreateOrderBody> & { buyerId: string }
+  orderBody: z.infer<typeof CreateOrderBody> & { buyerId: string }
 ) => {
-	const order = await prisma.order.create({
-		data: {
-			paymentMethod: orderBody.payment_method,
-			paymentStatus:
-				orderBody.payment_method === "VENMO" ? "PENDING" : "UNVERIFIABLE",
-			buyer: { connect: { id: orderBody.buyerId } },
-			fundraiser: { connect: { id: orderBody.fundraiserId } },
-			items: {
-				create: orderBody.items.map((item) => ({
-					quantity: item.quantity,
-					item: { connect: { id: item.itemId } },
-				})),
-			},
-		},
-		include: {
-			buyer: true,
-			fundraiser: {
-				select: {
-					id: true,
-					name: true,
-					description: true,
-					goalAmount: true,
-					imageUrls: true,
-					pickupLocation: true,
-					buyingStartsAt: true,
-					buyingEndsAt: true,
-					pickupStartsAt: true,
-					pickupEndsAt: true,
-					organization: {
-						select: {
-							id: true,
-							name: true,
-							description: true,
-							authorized: true,
-							logoUrl: true,
-						},
-					},
-				},
-			},
-		},
-	});
+  const order = await prisma.order.create({
+    data: {
+      paymentMethod: orderBody.payment_method,
+      paymentStatus:
+        orderBody.payment_method === "VENMO" ? "PENDING" : "UNVERIFIABLE",
+      buyer: { connect: { id: orderBody.buyerId } },
+      fundraiser: { connect: { id: orderBody.fundraiserId } },
+      items: {
+        create: orderBody.items.map((item) => ({
+          quantity: item.quantity,
+          item: { connect: { id: item.itemId } },
+        })),
+      },
+    },
+    include: {
+      buyer: true,
+      fundraiser: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          goalAmount: true,
+          imageUrls: true,
+          pickupLocation: true,
+          buyingStartsAt: true,
+          buyingEndsAt: true,
+          pickupStartsAt: true,
+          pickupEndsAt: true,
+          organization: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              authorized: true,
+              logoUrl: true,
+            },
+          },
+        },
+      },
+    },
+  });
 
-	// Invalidate analytics cache for the fundraiser when a new order is created
-	await invalidateFundraiserAnalyticsCache(orderBody.fundraiserId);
+  // Invalidate analytics cache for the fundraiser when a new order is created
+  await invalidateFundraiserAnalyticsCache(orderBody.fundraiserId);
 
-	return order;
+  return order;
 };
 
 export const completeOrderPickup = async (orderId: string) => {
-	const order = await prisma.order.update({
-		where: { id: orderId },
-		data: {
-			pickedUp: true,
-		},
-		include: {
-			buyer: true,
-			fundraiser: {
-				select: {
-					id: true,
-					name: true,
-					description: true,
-					goalAmount: true,
-					imageUrls: true,
-					pickupLocation: true,
-					buyingStartsAt: true,
-					buyingEndsAt: true,
-					pickupStartsAt: true,
-					pickupEndsAt: true,
-					organization: {
-						select: {
-							id: true,
-							name: true,
-							description: true,
-							authorized: true,
-							logoUrl: true,
-						},
-					},
-				},
-			},
-		},
-	});
+  const order = await prisma.order.update({
+    where: { id: orderId },
+    data: {
+      pickedUp: true,
+    },
+    include: {
+      buyer: true,
+      fundraiser: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          goalAmount: true,
+          imageUrls: true,
+          pickupLocation: true,
+          buyingStartsAt: true,
+          buyingEndsAt: true,
+          pickupStartsAt: true,
+          pickupEndsAt: true,
+          organization: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              authorized: true,
+              logoUrl: true,
+            },
+          },
+        },
+      },
+    },
+  });
 
-	// Invalidate analytics cache for the fundraiser when an order is picked up, so pending order and picked up order counts are not stale
-	await invalidateFundraiserAnalyticsCache(order.fundraiser.id);
+  // Invalidate analytics cache for the fundraiser when an order is picked up, so pending order and picked up order counts are not stale
+  await invalidateFundraiserAnalyticsCache(order.fundraiser.id);
 
-	return order;
+  return order;
 };
 
 export const confirmOrderPayment = async (orderId: string) => {
-	const order = await prisma.order.update({
-		where: { id: orderId },
-		data: {
-			paymentStatus: "CONFIRMED",
-		},
-		include: {
-			buyer: true,
-			fundraiser: {
-				select: {
-					id: true,
-					name: true,
-					description: true,
-					goalAmount: true,
-					imageUrls: true,
-					pickupLocation: true,
-					buyingStartsAt: true,
-					buyingEndsAt: true,
-					pickupStartsAt: true,
-					pickupEndsAt: true,
-					organization: {
-						select: {
-							id: true,
-							name: true,
-							description: true,
-							authorized: true,
-							logoUrl: true,
-						},
-					},
-				},
-			},
-		},
-	});
+  const order = await prisma.order.update({
+    where: { id: orderId },
+    data: {
+      paymentStatus: "CONFIRMED",
+    },
+    include: {
+      buyer: true,
+      fundraiser: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          goalAmount: true,
+          imageUrls: true,
+          pickupLocation: true,
+          buyingStartsAt: true,
+          buyingEndsAt: true,
+          pickupStartsAt: true,
+          pickupEndsAt: true,
+          organization: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              authorized: true,
+              logoUrl: true,
+            },
+          },
+        },
+      },
+    },
+  });
 
-	return order;
+  return order;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       mailgun.js:
         specifier: ^12.0.1
         version: 12.0.1
+      memjs:
+        specifier: ^1.3.2
+        version: 1.3.2
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -2742,6 +2745,10 @@ packages:
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
+
+  memjs@1.3.2:
+    resolution: {integrity: sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==}
+    engines: {node: '>=0.10.0'}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -6282,6 +6289,8 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   media-typer@0.3.0: {}
+
+  memjs@1.3.2: {}
 
   merge-descriptors@1.0.3: {}
 


### PR DESCRIPTION
This CR adds all the missing attributes for individual fundraiser data since this [PR](https://github.com/cornell-dti/curaise/pull/48) to replicate this documented JSON layout
```
{
	"total_revenue": double,
	"total_orders": integer,
	"revenue_picked_up": double,
	"orders_picked_up": integer,
	"items": {
		"<name_of_item>": integer, // units sold
		"<name_of_item>": integer,
		...
	},
	"pending_order": integer,
	"profit": integer,
	"goal_amount": double,
	"sales_data": {
		"<date>": integer, // orders sold
		"<date>": integer,
		"<date>": integer,
	},
	"revenue_data": {
		"<date>": integer, // revenues earn on that day
		"<date>": integer,
		"<date>": integer,
	}
	"start_date": string,
	"end_date": string
}
```
Furthermore, I also incorporated the cache invalidation logic when a new order is placed or when a order is confirmed to be picked up. The invalidate cache action is mandatory as we don't want staled data to persist in our cache when a fundraiser is still ongoing.

https://github.com/user-attachments/assets/0910be87-f507-4f8c-9bf2-c95f0fbc5ad5


