### PR TITLE
Fix issue #59 - Duplicate Orders on Checkout Page

### DIFF
--- a/frontend/src/app/buyer/fundraiser/[id]/checkout/components/CheckoutForm.tsx
+++ b/frontend/src/app/buyer/fundraiser/[id]/checkout/components/CheckoutForm.tsx
@@ -40,7 +40,15 @@ export function CheckoutForm({
     payment_method: "OTHER", // default to other for now
   });
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   async function onSubmit() {
+    // Prevent multiple submissions
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
     const dataToSubmit = {
       ...formData,
     };
@@ -60,6 +68,7 @@ export function CheckoutForm({
     const result = await response.json();
     if (!response.ok) {
       toast.error(result.message);
+      setIsSubmitting(false);
       return;
     } else {
       toast.success(result.message);
@@ -85,6 +94,7 @@ export function CheckoutForm({
           cartItems={cart}
           onSubmit={onSubmit}
           onBack={() => setCurrentStep(0)}
+          isSubmitting={isSubmitting}
         />
       </MultiStepForm>
     </div>

--- a/frontend/src/app/buyer/fundraiser/[id]/checkout/components/ReviewOrderForm.tsx
+++ b/frontend/src/app/buyer/fundraiser/[id]/checkout/components/ReviewOrderForm.tsx
@@ -20,11 +20,13 @@ export function ReviewOrderForm({
   cartItems,
   onSubmit,
   onBack,
+  isSubmitting,
 }: {
   fundraiser: z.infer<typeof CompleteFundraiserSchema>;
   cartItems: CartItem[];
   onSubmit: () => void;
   onBack: () => void;
+  isSubmitting: boolean;
 }) {
   const orderTotal = cartItems
     .reduce(
@@ -117,11 +119,11 @@ export function ReviewOrderForm({
         </Card>
 
         <div className="flex justify-between">
-          <Button variant="outline" onClick={onBack}>
+          <Button variant="outline" onClick={onBack} disabled={isSubmitting}>
             Back
           </Button>
-          <Button type="submit" onClick={onSubmit}>
-            Place Order
+          <Button type="submit" onClick={onSubmit} disabled={isSubmitting}>
+            {isSubmitting ? "Placing Order..." : "Place Order"}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
This PR fixes an issue where users could **create multiple duplicate orders** by rapidly clicking the **“Place Order”** button on the buyer checkout page. The submission button now correctly enters a loading/disabled state while the order request is processing. 

Closes #59

### Changes
- **`CheckoutForm.tsx`**
  - Added `isSubmitting` state to prevent repeated submissions.
  - Early return if a submission is already in progress.
  - Reset submission state when an error occurs.
  - Passed `isSubmitting` prop to the review form for button state control.

- **`ReviewOrderForm.tsx`**
  - Disabled **Back** and **Place Order** buttons during submission.
  - Updated button label to display *“Placing Order…”* for better UX feedback.

https://github.com/user-attachments/assets/63f00bf2-5ce1-4cbe-8f60-f722dd170ceb