### PR TITLE
Fix mailgun fields matching

### DIFF
--- a/backend/src/api/email/email.handlers.ts
+++ b/backend/src/api/email/email.handlers.ts
@@ -17,7 +17,7 @@ export const parseEmailHandler = async (
       from,
       subject,
       "body-html": bodyHtml,
-      "Body-plain": bodyPlain,
+      "body-plain": bodyPlain,
       timestamp,
       token,
       signature,
@@ -26,7 +26,11 @@ export const parseEmailHandler = async (
     // TODO: Verify Mailgun signature
 
     // Confirm sender is Venmo
-    if (from !== "venmo@venmo.com") {
+    // Mailgun sends from field like "Venmo <venmo@venmo.com>", extract email
+    const emailMatch = from.match(/<(.+?)>|^(.+)$/);
+    const emailAddress = emailMatch ? (emailMatch[1] || emailMatch[2]) : from;
+
+    if (emailAddress !== "venmo@venmo.com") {
       res.status(406).json({ message: "ignored sender" });
       return;
     }

--- a/backend/src/api/email/email.types.ts
+++ b/backend/src/api/email/email.types.ts
@@ -1,22 +1,23 @@
 import { z } from "zod";
 
 // https://documentation.mailgun.com/docs/mailgun/user-manual/receive-forward-store/receive-http
+// NOTE: Mailgun actually sends lowercase field names despite docs showing mixed case
 export const MailgunInboundEmailBody = z.object({
   recipient: z.string(),
   sender: z.string(),
   from: z.string(),
   subject: z.string().default(""),
-  "Body-plain": z.string().default(""),
+  "body-plain": z.string().default(""),
   "stripped-text": z.string().optional(),
   "stripped-signature": z.string().optional(),
   "body-html": z.string().optional(),
   "stripped-html": z.string().optional(),
-  "Attachment-count": z.coerce.number().default(0),
+  "attachment-count": z.coerce.number().default(0),
   timestamp: z.coerce.number(),
   token: z.string(),
   signature: z.string(),
   "message-headers": z.string().optional(),
-  "Content-id-map": z.string().optional(),
+  "content-id-map": z.string().optional(),
 });
 
 export type MailgunInboundEmailBody = z.infer<typeof MailgunInboundEmailBody>;


### PR DESCRIPTION
Aligns Mailgun field names to lowercase to match actual payloads and updates the Venmo sender check to extract the email address from "Venmo <venmo@venmo.com>". Ensures schema consistency and correct handling of inbound emails.