### PR TITLE
Remove User VenmoUserName Field

### DIFF
--- a/backend/prisma/migrations/20251114212445_remove_user_venmo/migration.sql
+++ b/backend/prisma/migrations/20251114212445_remove_user_venmo/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `venmo_username` on the `users` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "users_venmo_username_key";
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "venmo_username";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -9,11 +9,10 @@ datasource db {
 }
 
 model User {
-  id            String   @id @db.Uuid
-  email         String   @unique
-  name          String
-  venmoUsername String?  @unique @map("venmo_username")
-  createdAt     DateTime @default(now()) @map("created_at")
+  id        String   @id @db.Uuid
+  email     String   @unique
+  name      String
+  createdAt DateTime @default(now()) @map("created_at")
 
   organizations Organization[]
   orders        Order[]

--- a/backend/src/api/user/user.services.ts
+++ b/backend/src/api/user/user.services.ts
@@ -91,7 +91,6 @@ export const updateUser = async (
     where: { id: user.userId },
     data: {
       name: user.name,
-      venmoUsername: user.venmoUsername ?? null,
     },
   });
 

--- a/common/schemas/user.ts
+++ b/common/schemas/user.ts
@@ -4,18 +4,10 @@ export const UserSchema = z.object({
   id: z.string().uuid(),
   email: z.string().email(),
   name: z.string(),
-  venmoUsername: z.string().min(1).max(255).nullish(),
 });
 
 // CRUD BODIES:
 
 export const UpdateUserBody = z.object({
   name: z.string().min(1).max(255),
-  venmoUsername: z
-    .string()
-    .optional()
-    .transform((value) =>
-      value ? (value.length === 0 ? undefined : value) : undefined
-    )
-    .pipe(z.string().min(5).max(30).optional()),
 });

--- a/frontend/src/app/buyer/fundraiser/[id]/checkout/components/EditBuyerInfoForm.tsx
+++ b/frontend/src/app/buyer/fundraiser/[id]/checkout/components/EditBuyerInfoForm.tsx
@@ -48,7 +48,6 @@ export function EditBuyerInfoForm({
     resolver: zodResolver(UpdateUserBody),
     values: {
       name: data.name,
-      venmoUsername: data.venmoUsername ?? "",
     },
     resetOptions: {
       keepDirtyValues: true,
@@ -107,19 +106,6 @@ export function EditBuyerInfoForm({
                   <FormLabel>Name</FormLabel>
                   <FormControl>
                     <Input placeholder="Name" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="venmoUsername"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Venmo Username</FormLabel>
-                  <FormControl>
-                    <Input placeholder="No Username" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/frontend/src/components/custom/EditBuyerInfoDialog.tsx
+++ b/frontend/src/components/custom/EditBuyerInfoDialog.tsx
@@ -49,7 +49,6 @@ export function EditBuyerInfoDialog({
     resolver: zodResolver(UpdateUserBody),
     values: {
       name: data.name,
-      venmoUsername: data.venmoUsername ?? "",
     },
     resetOptions: {
       keepDirtyValues: true,
@@ -108,19 +107,6 @@ export function EditBuyerInfoDialog({
                     <FormLabel>Name</FormLabel>
                     <FormControl>
                       <Input placeholder="Name" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="venmoUsername"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Venmo Username</FormLabel>
-                    <FormControl>
-                      <Input placeholder="No Username" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>


### PR DESCRIPTION
This PR removes the useless user venmoUserName field.

DB/Prisma: Drop venmo_username column and unique index; remove from User model.

Backend: Remove all Zod schema fields and service-layer usage.

Frontend: Remove Venmo username inputs from Buyer Info forms and dialogs.