### PR TITLE
Minor Bug Fix to Add Paginations to ItemsSoldCard

### DIFF
--- a/frontend/src/app/seller/fundraiser/[id]/analytics/components/ItemsSoldCard.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/analytics/components/ItemsSoldCard.tsx
@@ -37,7 +37,7 @@ export function ItemsSoldCard({ items }: ItemsSoldCardProps) {
 
 	return (
 		<div className="space-y-6">
-			<div className="space-y-6">
+			<div className="space-y-6 min-h-[200px]">
 				{currentItems.map((item, index) => {
 					const percentage = total > 0 ? (item.quantity / total) * 100 : 0;
 					return (
@@ -74,8 +74,7 @@ export function ItemsSoldCard({ items }: ItemsSoldCardProps) {
 						size="sm"
 						onClick={goToPrevPage}
 						disabled={currentPage === 1}>
-						<ChevronLeft className="h-4 w-4" />
-						Prev
+						Previous
 					</Button>
 					<Button
 						variant="outline"
@@ -83,7 +82,6 @@ export function ItemsSoldCard({ items }: ItemsSoldCardProps) {
 						onClick={goToNextPage}
 						disabled={currentPage === totalPages}>
 						Next
-						<ChevronRight className="h-4 w-4" />
 					</Button>
 				</div>
 			)}


### PR DESCRIPTION
This PR addresses a minor UI bug where we lack pagination and once items exceed a certain limit then the card get stretched and that is not aesthetic
<img width="1375" height="443" alt="image" src="https://github.com/user-attachments/assets/c4a1efec-3d14-4e64-9f23-50013bffadef" />
