### PR TITLE
Add admin list dropdown in EditOrgInfoDialog

### DIFF
--- a/frontend/src/components/custom/EditOrgInfoDialog.tsx
+++ b/frontend/src/components/custom/EditOrgInfoDialog.tsx
@@ -12,6 +12,14 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  DropdownMenu,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
 import { CompleteOrganizationSchema } from "common";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
@@ -201,6 +209,23 @@ export function EditOrgInfoDialog({
               {/* Add Admins Section */}
               <div className="border-t pt-4 mt-2">
                 <FormLabel className="block mb-2">
+                  Current Admins
+                </FormLabel>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant={"outline"}>
+                      View {data.admins.length} Admin{data.admins.length !== 1 ? "s" : ""}
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuLabel>Admins</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {data.admins.map((admin) => (
+                      <DropdownMenuItem key={admin.id}>{admin.name} ({admin.email})</DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <FormLabel className="block mb-2 mt-4">
                   Add Additional Admins (Optional)
                 </FormLabel>
                 <div className="flex gap-2">


### PR DESCRIPTION
**Added a dropdown menu to view current admins' name and emails by clicking the "View X Admins" button in EditOrgInfoDialog. This feature utilized the dropdown-menu UI component.**

<img width="441" height="633" alt="image" src="https://github.com/user-attachments/assets/bd513b53-d81f-4e7b-bb40-e3b84fca10b4" />


---
**Actual admin names and emails are replaced with placeholder values for privacy reasons in the example image below:**

<img width="441" height="633" alt="image" src="https://github.com/user-attachments/assets/25bdc896-6c78-4a6b-8f2c-546c14cde2b6"/>


