### PR TITLE
Auto accept gmail forwarding

### DIFF
--- a/backend/src/api/email/email.handlers.ts
+++ b/backend/src/api/email/email.handlers.ts
@@ -7,11 +7,38 @@ import {
   parseVerifiedVenmoEmail,
   updateOrderPaymentStatus,
 } from "./email.services";
+import { sendEmail } from "../../utils/email";
+
+const ON_CALL_EMAIL = process.env.ON_CALL_EMAIL;
+
+async function forwardToOnCall(options: {
+  reason: string;
+  subject: string | undefined;
+  bodyHtml: string | undefined;
+  bodyPlain: string | undefined;
+}) {
+  if (!ON_CALL_EMAIL) {
+    console.warn("ON_CALL_EMAIL not set; skipping on-call forward");
+    return;
+  }
+  try {
+    await sendEmail({
+      to: ON_CALL_EMAIL,
+      subject: `[CURaise] Gmail forwarding auto-confirm ${options.reason}: ${options.subject ?? "(no subject)"}`,
+      text: options.bodyPlain,
+      html: options.bodyHtml,
+    });
+  } catch (err) {
+    console.error("Failed to forward auto-confirm failure to on-call:", err);
+  }
+}
+
+type ConfirmResult = "confirmed" | "not-found" | "failed";
 
 async function autoConfirmForwarding(
   bodyHtml: string | undefined,
   bodyPlain: string | undefined
-): Promise<boolean> {
+): Promise<ConfirmResult> {
   const confirmUrlPattern = /https:\/\/mail\.google\.com\/mail\/vf-[^\s"<>]+/;
 
   // Try HTML first
@@ -22,8 +49,12 @@ async function autoConfirmForwarding(
       const url = links.first().attr("href");
       if (url) {
         const response = await fetch(url, { method: "POST" });
+        if (!response.ok) {
+          console.warn(`Forwarding confirmation POST failed: ${url} (status: ${response.status})`);
+          return "failed";
+        }
         console.log(`Forwarding confirmed via HTML link: ${url} (status: ${response.status})`);
-        return true;
+        return "confirmed";
       }
     }
   }
@@ -34,11 +65,15 @@ async function autoConfirmForwarding(
   if (match) {
     const url = match[0];
     const response = await fetch(url, { method: "POST" });
+    if (!response.ok) {
+      console.warn(`Forwarding confirmation POST failed: ${url} (status: ${response.status})`);
+      return "failed";
+    }
     console.log(`Forwarding confirmed via text link: ${url} (status: ${response.status})`);
-    return true;
+    return "confirmed";
   }
 
-  return false;
+  return "not-found";
 }
 
 export const parseEmailHandler = async (
@@ -61,15 +96,20 @@ export const parseEmailHandler = async (
     // Auto-confirm Gmail forwarding requests
     if (from.includes("forwarding-noreply@google.com")) {
       try {
-        const confirmed = await autoConfirmForwarding(bodyHtml, bodyPlain);
-        if (confirmed) {
+        const result = await autoConfirmForwarding(bodyHtml, bodyPlain);
+        if (result === "confirmed") {
           res.status(200).json({ message: "forwarding confirmed" });
+        } else if (result === "failed") {
+          await forwardToOnCall({ reason: "POST failed", subject, bodyHtml, bodyPlain });
+          res.status(200).json({ message: "forwarding confirmation failed" });
         } else {
           console.warn("Gmail forwarding email received but no confirmation URL found");
+          await forwardToOnCall({ reason: "no confirmation URL", subject, bodyHtml, bodyPlain });
           res.status(200).json({ message: "no confirmation url found" });
         }
       } catch (err) {
         console.error("Failed to auto-confirm forwarding:", err);
+        await forwardToOnCall({ reason: "exception", subject, bodyHtml, bodyPlain });
         res.status(200).json({ message: "forwarding confirmation failed" });
       }
       return;

--- a/backend/src/api/email/email.handlers.ts
+++ b/backend/src/api/email/email.handlers.ts
@@ -8,6 +8,39 @@ import {
   updateOrderPaymentStatus,
 } from "./email.services";
 
+async function autoConfirmForwarding(
+  bodyHtml: string | undefined,
+  bodyPlain: string | undefined
+): Promise<boolean> {
+  const confirmUrlPattern = /https:\/\/mail\.google\.com\/mail\/vf-[^\s"<>]+/;
+
+  // Try HTML first
+  if (bodyHtml) {
+    const $ = load(bodyHtml);
+    const links = $("a[href*='mail.google.com/mail/vf-']");
+    if (links.length > 0) {
+      const url = links.first().attr("href");
+      if (url) {
+        const response = await fetch(url, { method: "POST" });
+        console.log(`Forwarding confirmed via HTML link: ${url} (status: ${response.status})`);
+        return true;
+      }
+    }
+  }
+
+  // Fall back to plain text regex
+  const text = bodyPlain || bodyHtml || "";
+  const match = text.match(confirmUrlPattern);
+  if (match) {
+    const url = match[0];
+    const response = await fetch(url, { method: "POST" });
+    console.log(`Forwarding confirmed via text link: ${url} (status: ${response.status})`);
+    return true;
+  }
+
+  return false;
+}
+
 export const parseEmailHandler = async (
   req: Request<{}, any, MailgunInboundEmailBody, {}>,
   res: Response
@@ -24,6 +57,23 @@ export const parseEmailHandler = async (
     } = req.body;
 
     // TODO: Verify Mailgun signature
+
+    // Auto-confirm Gmail forwarding requests
+    if (from.includes("forwarding-noreply@google.com")) {
+      try {
+        const confirmed = await autoConfirmForwarding(bodyHtml, bodyPlain);
+        if (confirmed) {
+          res.status(200).json({ message: "forwarding confirmed" });
+        } else {
+          console.warn("Gmail forwarding email received but no confirmation URL found");
+          res.status(200).json({ message: "no confirmation url found" });
+        }
+      } catch (err) {
+        console.error("Failed to auto-confirm forwarding:", err);
+        res.status(200).json({ message: "forwarding confirmation failed" });
+      }
+      return;
+    }
 
     // Confirm sender is Venmo
     if (from !== "Venmo <venmo@venmo.com>") {


### PR DESCRIPTION
Automatically confirms Gmail forwarding verification emails in email/parse, so we don't need to manually click the confirm link when setting up email forwarding to postmaster@curaise.app.