### PR TITLE
Added order status sorting and hint to seller table

### DIFF
--- a/frontend/src/app/seller/fundraiser/[id]/orders/components/TableColumns.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/orders/components/TableColumns.tsx
@@ -24,6 +24,7 @@ import {
   AlertDialogAction,
 } from "@/components/ui/alert-dialog";
 import { ArrowUpDown } from "lucide-react";
+import { InfoTooltip } from "@/components/custom/MoreInfoToolTip";
 import { z } from "zod";
 import { CompleteOrderSchema } from "common/schemas/order";
 import { toast } from "sonner";
@@ -433,9 +434,37 @@ export const getColumns = (token: string): ColumnDef<Order>[] => [
   },
   {
     accessorKey: "paymentStatus",
-    header: () => {
+    // Return the displayed status for sorting (matches what user sees)
+    accessorFn: (row) => {
+      if (row.pickedUp) return "Picked Up";
+      if (row.paymentStatus === "UNVERIFIABLE") return "Unverifiable";
+      if (row.paymentStatus === "PENDING") return "Pending";
+      if (row.paymentStatus === "CONFIRMED") return "Not Picked Up";
+      return "Unknown";
+    },
+    header: ({ column }) => {
       return (
-        <div className="flex justify-center w-full px-2">Order Status</div>
+        <div className="flex items-center justify-center w-full px-2 gap-1">
+          <Button
+            variant="ghost"
+            className="px-2"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Order Status
+            <ArrowUpDown className="ml-1 h-3 w-3" />
+          </Button>
+          <InfoTooltip
+            content={
+              <>
+                • <strong>Pending:</strong> Payment not yet verified
+                <br />• <strong>Not Picked Up:</strong> Payment confirmed, awaiting pickup
+                <br />• <strong>Picked Up:</strong> Order complete
+                <br />• <strong>Unverifiable:</strong> Payment can&apos;t be verified (cash/manual order), but can be picked up
+              </>
+            }
+            size={18}
+          />
+        </div>
       );
     },
     filterFn: "arrIncludesSome",

--- a/frontend/src/components/custom/MoreInfoToolTip.tsx
+++ b/frontend/src/components/custom/MoreInfoToolTip.tsx
@@ -8,7 +8,7 @@ import { HelpCircle } from "lucide-react";
 
 interface InfoTooltipProps {
   /** The informational text shown on hover */
-  content: string;
+  content: React.ReactNode;
   /** Optional size of the ? icon in pixels (default 18) */
   size?: number;
   className?: string;
@@ -41,7 +41,7 @@ export function InfoTooltip({
       <TooltipContent
         side="top"
         sideOffset={6}
-        className="max-w-64 text-xs leading-relaxed"
+        className="max-w-64 text-xs leading-relaxed whitespace-pre-line"
       >
         {content}
       </TooltipContent>


### PR DESCRIPTION
Adds an `Order Status` sorting button and a `?` hint to the seller order table

<img width="399" height="270" alt="image" src="https://github.com/user-attachments/assets/8201ee46-02f4-4c31-a14b-f79213b7cc52" />
