### PR TITLE
Add copy Venmo link button to order payment card

### DIFF
--- a/frontend/src/app/buyer/order/[id]/page.tsx
+++ b/frontend/src/app/buyer/order/[id]/page.tsx
@@ -226,7 +226,7 @@ export default async function OrderPage({
                   </div>
                 ) : (
                   <div className="space-y-4">
-                    <div className="flex justify-center">
+                    <div className="flex flex-col items-center gap-2">
                       <Button
                         size="lg"
                         asChild
@@ -266,6 +266,11 @@ export default async function OrderPage({
                           </span>
                         </a>
                       </Button>
+                      <CopyButton
+                        text={`https://venmo.com/${fundraiser.venmoUsername}?txn=pay&note=${encodeURIComponent(orderIdForPayment)}&amount=${encodeURIComponent(orderTotal)}`}
+                        label="Copy Link"
+                        variant="outline"
+                      />
                     </div>
 
                     {/* Show payment details */}

--- a/frontend/src/components/custom/CopyButton.tsx
+++ b/frontend/src/components/custom/CopyButton.tsx
@@ -6,17 +6,33 @@ import { toast } from "sonner";
 
 interface CopyButtonProps {
   text: string;
+  label?: string;
+  variant?: "ghost" | "outline" | "default" | "secondary" | "destructive" | "link";
 }
 
-export function CopyButton({ text }: CopyButtonProps) {
+export function CopyButton({ text, label, variant = "ghost" }: CopyButtonProps) {
   const copyText = () => {
     navigator.clipboard.writeText(text);
     toast.success("Copied to clipboard!");
   };
 
+  if (label) {
+    return (
+      <Button
+        variant={variant}
+        size="lg"
+        onClick={copyText}
+        className="flex items-center gap-2 px-4 py-3 text-md"
+      >
+        <Copy className="h-4 w-4" />
+        <span>{label}</span>
+      </Button>
+    );
+  }
+
   return (
     <Button
-      variant="ghost"
+      variant={variant}
       size="sm"
       onClick={copyText}
       className="h-6 w-6 p-0 hover:bg-gray-100 dark:hover:bg-gray-800"


### PR DESCRIPTION
- Add a "Copy Link" button below the "Pay with Venmo" button so buyers can easily copy the Venmo payment link
- Mobile and desktop responsive
- Extend CopyButton component to support a label prop and configurable variant, so we can re-use this component