### PR TITLE
Fix seller analytics responsiveness

### DIFF
--- a/frontend/src/app/seller/fundraiser/[id]/analytics/components/ProfitGoalChart.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/analytics/components/ProfitGoalChart.tsx
@@ -51,7 +51,7 @@ export function ProfitGoalChart({ profit, goalAmount }: ProfitGoalChartProps) {
 	return (
 		<ChartContainer
 			config={chartConfig}
-			className="mx-auto aspect-square max-h-[250px] max-w-[250px]">
+			className="mx-auto aspect-square w-full max-w-[250px]">
 			<PieChart>
 				<ChartTooltip
 					cursor={false}

--- a/frontend/src/app/seller/fundraiser/[id]/analytics/components/RealtimeAnalyticsWrapper.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/analytics/components/RealtimeAnalyticsWrapper.tsx
@@ -195,7 +195,7 @@ export function RealtimeAnalyticsWrapper({
   return (
     <div className="mb-6">
       <h2 className="text-xl font-bold mb-6">Key Insights</h2>
-      <div className="grid grid-cols-[0.6fr_1fr_1fr_1.5fr] gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 min-[1400px]:grid-cols-[0.6fr_1fr_1fr_1.5fr] gap-6">
         {/* First Column - Revenue and Total Orders stacked */}
         <div className="flex flex-col gap-6 h-full">
           {/* Revenue Card */}
@@ -210,65 +210,67 @@ export function RealtimeAnalyticsWrapper({
           </div>
 
           {/* Total Orders Card */}
-          <div className="bg-white rounded-lg shadow p-6 flex-1">
+          <div className="bg-white rounded-lg shadow p-6 flex-1 flex flex-col">
             <div className="flex items-center gap-2 mb-2 font-semibold">
               <Receipt />
               Total Orders
             </div>
-            <div className="flex items-end gap-5">
-              <div className="text-4xl font-semibold leading-none">
-                {analytics.total_orders}
-              </div>
-              <div className="space-y-1.5 pb-0.5 text-sm leading-none text-muted-foreground">
-                <div>
-                  <span className="font-semibold text-foreground">
-                    {analytics.total_orders - analytics.pending_orders}
-                  </span>{" "}
-                  Confirmed
-                </div>
-                <div>
-                  <span className="font-semibold text-foreground">
-                    {analytics.pending_orders}
-                  </span>{" "}
-                  Pending
-                </div>
-              </div>
+            <div className="text-3xl font-semibold">
+              {analytics.total_orders}
+            </div>
+            <div className="flex gap-3 mt-2 text-sm text-muted-foreground">
+              <span className="whitespace-nowrap">
+                <span className="font-semibold text-foreground">
+                  {analytics.total_orders - analytics.pending_orders}
+                </span>{" "}
+                Confirmed
+              </span>
+              <span className="whitespace-nowrap">
+                <span className="font-semibold text-foreground">
+                  {analytics.pending_orders}
+                </span>{" "}
+                Pending
+              </span>
             </div>
           </div>
         </div>
 
         {/* Profit Goal Card */}
-        <div className="bg-white rounded-lg shadow p-6 overflow-hidden">
+        <div className="bg-white rounded-lg shadow p-6 overflow-hidden flex flex-col">
           <div className="flex items-center gap-2 mb-4 font-semibold">
-            <Goal />
+            <Goal className="shrink-0" />
             Profit Goal
             <InfoTooltip
               content="Profit is estimated using a 20% profit margin."
               size={18}
             />
           </div>
-          <ProfitGoalChart
-            profit={analytics.profit}
-            goalAmount={goalAmount}
-          />
+          <div className="flex-1 flex items-center justify-center">
+            <ProfitGoalChart
+              profit={analytics.profit}
+              goalAmount={goalAmount}
+            />
+          </div>
         </div>
 
         {/* Revenue Breakdown Card */}
-        <div className="bg-white rounded-lg shadow p-6 overflow-hidden">
-          <div className="flex items-center gap-2 mb-4 font-semibold">
-            <Receipt />
+        <div className="bg-white rounded-lg shadow p-6 overflow-hidden flex flex-col">
+          <div className="flex items-center gap-2 mb-4 font-semibold whitespace-nowrap">
+            <Receipt className="shrink-0" />
             Revenue Breakdown
           </div>
-          <RevenueBreakdownChart
-            itemRevenue={itemRevenue}
-            totalRevenue={analytics.total_revenue}
-          />
+          <div className="flex-1 flex items-center justify-center">
+            <RevenueBreakdownChart
+              itemRevenue={itemRevenue}
+              totalRevenue={analytics.total_revenue}
+            />
+          </div>
         </div>
 
         {/* Items Sold Card */}
         <div className="bg-white rounded-lg shadow p-6">
           <div className="flex items-center gap-2 mb-4 font-semibold">
-            <Receipt />
+            <Receipt className="shrink-0" />
             Item Performance
             <InfoTooltip
               content="Sorted by confirmed units sold. Inventory caps are affected only by confirmed or picked-up orders, not carts or unpaid pending orders."

--- a/frontend/src/app/seller/fundraiser/[id]/analytics/components/RevenueBreakdownChart.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/analytics/components/RevenueBreakdownChart.tsx
@@ -62,7 +62,7 @@ export function RevenueBreakdownChart({
 	return (
 		<ChartContainer
 			config={chartConfig}
-			className="mx-auto aspect-square max-h-[250px] max-w-[250px]">
+			className="mx-auto aspect-square w-full max-w-[250px]">
 			<PieChart>
 				<ChartTooltip
 					cursor={false}

--- a/frontend/src/app/seller/fundraiser/[id]/components/FundraiserHeader.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/components/FundraiserHeader.tsx
@@ -80,10 +80,10 @@ export function FundraiserHeader({
       />
 
       <div>
-        <div className="w-full flex justify-between">
+        <div className="w-full flex flex-wrap justify-between gap-3">
           <h1 className="text-[32px] font-semibold">{fundraiser.name}</h1>
           <div className="flex flex-col gap-3 items-end">
-            <div className="flex gap-4">
+            <div className="flex flex-wrap gap-4">
               <Link href={`/buyer/fundraiser/${fundraiser.id}?preview=true`}>
                 <Button className="w-[100px] bg-[#265B34] text-white hover:bg-[#1f4a2b]">
                   Preview

--- a/frontend/src/app/seller/fundraiser/[id]/orders/components/OrdersTable.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/orders/components/OrdersTable.tsx
@@ -151,7 +151,7 @@ export function OrdersTable<TValue>({
 			</div>
 
 			<div className="rounded-md border">
-				<Table className="min-w-[1100px]">
+				<Table className="min-w-[1300px]">
 					<TableHeader>
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow key={headerGroup.id}>

--- a/frontend/src/app/seller/fundraiser/[id]/orders/components/OrdersTable.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/orders/components/OrdersTable.tsx
@@ -151,7 +151,7 @@ export function OrdersTable<TValue>({
 			</div>
 
 			<div className="rounded-md border">
-				<Table className="min-w-[1300px]">
+				<Table className="min-w-[1200px]">
 					<TableHeader>
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow key={headerGroup.id}>

--- a/frontend/src/app/seller/fundraiser/[id]/orders/components/OrdersTable.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/orders/components/OrdersTable.tsx
@@ -151,7 +151,7 @@ export function OrdersTable<TValue>({
 			</div>
 
 			<div className="rounded-md border">
-				<Table>
+				<Table className="min-w-[1100px]">
 					<TableHeader>
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow key={headerGroup.id}>

--- a/frontend/src/app/seller/fundraiser/[id]/orders/components/OrdersTable.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/orders/components/OrdersTable.tsx
@@ -151,7 +151,7 @@ export function OrdersTable<TValue>({
 			</div>
 
 			<div className="rounded-md border">
-				<Table className="min-w-[1200px]">
+				<Table className="min-w-[1150px]">
 					<TableHeader>
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow key={headerGroup.id}>

--- a/frontend/src/app/seller/fundraiser/[id]/orders/components/TableColumns.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/orders/components/TableColumns.tsx
@@ -313,7 +313,7 @@ export const getColumns = (token: string): ColumnDef<Order>[] => [
       ).padStart(2, "0")}`;
 
       return (
-        <div className="flex items-center justify-center">{createdAtStr}</div>
+        <div className="flex items-center justify-center whitespace-nowrap">{createdAtStr}</div>
       );
     },
   },
@@ -349,7 +349,7 @@ export const getColumns = (token: string): ColumnDef<Order>[] => [
           {items.map((item) => (
             <div
               key={`${item.item.id}-name`}
-              className="py-1 w-full text-center"
+              className="h-[2.5rem] flex items-center justify-center w-full text-center leading-tight"
             >
               {item.item.name}
             </div>
@@ -368,7 +368,7 @@ export const getColumns = (token: string): ColumnDef<Order>[] => [
           {items.map((item) => (
             <div
               key={`${item.item.id}-name`}
-              className="py-1 w-full text-center"
+              className="h-[2.5rem] flex items-center justify-center w-full text-center"
             >
               {item.quantity}
             </div>

--- a/frontend/src/app/seller/fundraiser/[id]/referrals/components/ReferralsTable.tsx
+++ b/frontend/src/app/seller/fundraiser/[id]/referrals/components/ReferralsTable.tsx
@@ -71,7 +71,7 @@ export function ReferralsTable<TValue>({
 			</div>
 
 			<div className="rounded-md border">
-				<Table>
+				<Table className="min-w-[600px]">
 					<TableHeader>
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow key={headerGroup.id}>

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -73,7 +73,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
       className
     )}
     {...props}


### PR DESCRIPTION
- Make Key Insights grid responsive (1/2/4 columns, splits at 1400px)
- Fix donut charts not staying level when headers wrap
- Fix header buttons overflowing on mobile
- Add min-width + horizontal scroll to seller tables to prevent text wrapping
- Fix item-quantity row alignment in orders table