### PR TITLE
enforce @cornell.edu domain at auth boundaries

### DIFF
--- a/backend/src/middleware/authenticate.ts
+++ b/backend/src/middleware/authenticate.ts
@@ -6,6 +6,13 @@ const supabase = createClient(
   process.env.SUPABASE_SERVICE_KEY as string
 );
 
+const ALLOWED_EMAIL_DOMAIN = "@cornell.edu";
+
+const hasAllowedEmail = (email: string | undefined | null): boolean => {
+  if (!email) return false;
+  return email.toLowerCase().endsWith(ALLOWED_EMAIL_DOMAIN);
+};
+
 // authenticates user by checking the authorization header JWT
 // attaches the Supabase user object to res.locals
 // note: only checks that the supabase user is authenticated, not that the user is authorized to perform an action
@@ -26,6 +33,14 @@ export const authenticate = async <ParamsT, BodyT, QueryT>(
     return;
   }
 
+  if (!hasAllowedEmail(user.email)) {
+    res.status(403).json({
+      message:
+        "CURaise is restricted to @cornell.edu accounts. Please sign in with your Cornell email.",
+    });
+    return;
+  }
+
   res.locals.user = user;
 
   next();
@@ -43,7 +58,7 @@ export const authenticateOptional = async <ParamsT, BodyT, QueryT>(
     req.headers.authorization?.split("Bearer ")[1]
   );
 
-  if (user) {
+  if (user && hasAllowedEmail(user.email)) {
     res.locals.user = user;
   }
 

--- a/frontend/src/app/auth/auth-code-error/page.tsx
+++ b/frontend/src/app/auth/auth-code-error/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default async function AuthCodeErrorPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ reason?: string }>;
+}) {
+  const { reason } = await searchParams;
+
+  const isNonCornell = reason === "non_cornell";
+
+  const title = isNonCornell
+    ? "Cornell email required"
+    : "Sign-in error";
+
+  const body = isNonCornell
+    ? "CURaise is only available to users with a @cornell.edu Google account. Please sign in again using your Cornell email."
+    : "We couldn't complete your sign-in. Please try again.";
+
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10 bg-white">
+      <div className="w-full max-w-md space-y-6 text-center font-[dm_sans]">
+        <h1 className="text-2xl sm:text-3xl font-[700] text-black">{title}</h1>
+        <p className="text-base sm:text-lg text-black font-[400]">{body}</p>
+        <div className="flex justify-center">
+          <Link href="/">
+            <Button
+              variant="secondary"
+              className="font-[dm_sans] font-[300] text-base sm:text-lg bg-[#33363F] text-white hover:bg-[#50535d] rounded-lg h-12 px-6"
+            >
+              Back to sign in
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -1,7 +1,31 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 // The client you created from the Server-Side Auth instructions
 import { sanitizeNextPath } from "@/lib/auth-redirect";
 import { createClient } from "@/utils/supabase/server";
+
+const ALLOWED_EMAIL_DOMAIN = "@cornell.edu";
+
+function isAllowedEmail(email: string | undefined | null): boolean {
+  if (!email) return false;
+  return email.toLowerCase().endsWith(ALLOWED_EMAIL_DOMAIN);
+}
+
+async function redirectWithClearedSession(url: string): Promise<NextResponse> {
+  const response = NextResponse.redirect(url);
+  const cookieStore = await cookies();
+  for (const c of cookieStore.getAll()) {
+    if (c.name.startsWith("sb-")) response.cookies.delete(c.name);
+  }
+  return response;
+}
+
+function resolveBase(request: Request, origin: string): string {
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  const isLocalEnv = process.env.NODE_ENV === "development";
+  if (isLocalEnv) return origin;
+  return forwardedHost ? `https://${forwardedHost}` : origin;
+}
 
 // Route Handler to handle the callback from the OAuth provider
 // This route is called after the user logs in with the OAuth provider and handles the code exchange to save the user session to cookies.
@@ -19,15 +43,18 @@ export async function GET(request: Request) {
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      const forwardedHost = request.headers.get("x-forwarded-host");
-      const isLocalEnv = process.env.NODE_ENV === "development";
-      const base = isLocalEnv
-        ? origin
-        : forwardedHost
-          ? `https://${forwardedHost}`
-          : origin;
+      const {
+        data: { user: sessionUser },
+      } = await supabase.auth.getUser();
 
-      return NextResponse.redirect(new URL(next, base));
+      if (!isAllowedEmail(sessionUser?.email)) {
+        await supabase.auth.signOut();
+        return redirectWithClearedSession(
+          `${origin}/auth/auth-code-error?reason=non_cornell`
+        );
+      }
+
+      return NextResponse.redirect(new URL(next, resolveBase(request, origin)));
     } else {
       console.log("[auth/callback] exchangeCodeForSession error:", error);
     }
@@ -35,14 +62,13 @@ export async function GET(request: Request) {
 
   // If user is already logged in, redirect to 'next' instead of error page
   if (existingUser) {
-    const forwardedHost = request.headers.get("x-forwarded-host");
-    const isLocalEnv = process.env.NODE_ENV === "development";
-    const base = isLocalEnv
-      ? origin
-      : forwardedHost
-        ? `https://${forwardedHost}`
-        : origin;
-    return NextResponse.redirect(new URL(next, base));
+    if (!isAllowedEmail(existingUser.email)) {
+      await supabase.auth.signOut();
+      return redirectWithClearedSession(
+        `${origin}/auth/auth-code-error?reason=non_cornell`
+      );
+    }
+    return NextResponse.redirect(new URL(next, resolveBase(request, origin)));
   }
   // Otherwise, return the user to an error page with instructions
   return NextResponse.redirect(`${origin}/auth/auth-code-error`);


### PR DESCRIPTION
- Backend `authenticate` middleware: returns 403 for JWTs whose email is not `@cornell.edu`; `authenticateOptional` silently drops them
- Frontend `/auth/callback`: validates email domain after `exchangeCodeForSession` and on existing-user path; calls `signOut()` and clears `sb-*` cookies on the redirect response when domain check fails
- New `/auth/auth-code-error` page with Cornell-only messaging and link back to landing

http://localhost:8080/auth/auth-code-error?reason=non_cornell
<img width="613" height="370" alt="image" src="https://github.com/user-attachments/assets/0b75ca1f-967a-4cf1-b9ed-5904d337f091" />
