### PR TITLE
Eddie standardize image aspect ratio

### DIFF
--- a/frontend/src/app/buyer/browse/components/BrowseFundraiserCard.tsx
+++ b/frontend/src/app/buyer/browse/components/BrowseFundraiserCard.tsx
@@ -13,7 +13,7 @@ export function BrowseFundraiserCard({ fundraiser }: BrowseFundraiserCardProps) 
       href={`/buyer/fundraiser/${fundraiser.id}`}
       className="flex flex-col gap-[15px] w-full"
     >
-      <div className="bg-white aspect-[3/2] w-full rounded-md shadow-[2px_2px_5px_0px_rgba(140,140,140,0.25)] overflow-hidden relative">
+      <div className="bg-white aspect-[16/9] w-full rounded-md shadow-[2px_2px_5px_0px_rgba(140,140,140,0.25)] overflow-hidden relative">
         {fundraiser.imageUrls && fundraiser.imageUrls.length > 0 ? (
           <Image
             src={fundraiser.imageUrls[0]}

--- a/frontend/src/app/buyer/browse/components/BrowseFundraiserCard.tsx
+++ b/frontend/src/app/buyer/browse/components/BrowseFundraiserCard.tsx
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { BasicFundraiserSchema } from "common";
+import Link from "next/link";
+import Image from "next/image";
+
+interface BrowseFundraiserCardProps {
+  fundraiser: z.infer<typeof BasicFundraiserSchema>;
+}
+
+export function BrowseFundraiserCard({ fundraiser }: BrowseFundraiserCardProps) {
+  return (
+    <Link
+      href={`/buyer/fundraiser/${fundraiser.id}`}
+      className="flex flex-col gap-[15px] w-full"
+    >
+      <div className="bg-white h-[240px] rounded-md shadow-[2px_2px_5px_0px_rgba(140,140,140,0.25)] overflow-hidden relative">
+        {fundraiser.imageUrls && fundraiser.imageUrls.length > 0 ? (
+          <Image
+            src={fundraiser.imageUrls[0]}
+            alt={fundraiser.name}
+            fill
+            className="object-cover"
+            sizes="100vw"
+            style={{ objectFit: "cover" }}
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-gray-200">
+            <span className="text-gray-400">No image</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1 w-full">
+        <h3 className="text-[20px] font-semibold leading-6 text-black">
+          {fundraiser.name}
+        </h3>
+        <p className="text-base font-normal leading-6 text-[#545454]">
+          {fundraiser.organization?.name || "Organization"}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/app/buyer/browse/components/BrowseFundraiserCard.tsx
+++ b/frontend/src/app/buyer/browse/components/BrowseFundraiserCard.tsx
@@ -13,7 +13,7 @@ export function BrowseFundraiserCard({ fundraiser }: BrowseFundraiserCardProps) 
       href={`/buyer/fundraiser/${fundraiser.id}`}
       className="flex flex-col gap-[15px] w-full"
     >
-      <div className="bg-white h-[240px] rounded-md shadow-[2px_2px_5px_0px_rgba(140,140,140,0.25)] overflow-hidden relative">
+      <div className="bg-white aspect-[3/2] w-full rounded-md shadow-[2px_2px_5px_0px_rgba(140,140,140,0.25)] overflow-hidden relative">
         {fundraiser.imageUrls && fundraiser.imageUrls.length > 0 ? (
           <Image
             src={fundraiser.imageUrls[0]}

--- a/frontend/src/app/buyer/browse/components/FundraisersList.tsx
+++ b/frontend/src/app/buyer/browse/components/FundraisersList.tsx
@@ -16,9 +16,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import Link from "next/link";
-import Image from "next/image";
 import { isPast } from "date-fns";
+import { BrowseFundraiserCard } from "./BrowseFundraiserCard";
 
 type FilterType = "all" | "pickup-today";
 // type CategoryType = "desserts" | "food" | "crafts" | "drinks" | "all";
@@ -172,39 +171,7 @@ export function FundraisersList({
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-[50px]">
           {filteredFundraisers.map((fundraiser) => (
-            <Link
-              key={fundraiser.id}
-              href={`/buyer/fundraiser/${fundraiser.id}`}
-              className="flex flex-col gap-[15px] w-full"
-            >
-              {/* Image */}
-              <div className="bg-white h-[240px] rounded-md shadow-[2px_2px_5px_0px_rgba(140,140,140,0.25)] overflow-hidden relative">
-                {fundraiser.imageUrls && fundraiser.imageUrls.length > 0 ? (
-                  <Image
-                    src={fundraiser.imageUrls[0]}
-                    alt={fundraiser.name}
-                    fill
-                    className="object-cover"
-                    sizes="100vw"
-                    style={{ objectFit: "cover" }}
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center bg-gray-200">
-                    <span className="text-gray-400">No image</span>
-                  </div>
-                )}
-              </div>
-
-              {/* Title and Organization */}
-              <div className="flex flex-col gap-1 w-full">
-                <h3 className="text-[20px] font-semibold leading-6 text-black">
-                  {fundraiser.name}
-                </h3>
-                <p className="text-base font-normal leading-6 text-[#545454]">
-                  {fundraiser.organization?.name || "Organization"}
-                </p>
-              </div>
-            </Link>
+            <BrowseFundraiserCard key={fundraiser.id} fundraiser={fundraiser} />
           ))}
         </div>
       )}

--- a/frontend/src/app/buyer/fundraiser/[id]/components/FundraiserGallerySlider.tsx
+++ b/frontend/src/app/buyer/fundraiser/[id]/components/FundraiserGallerySlider.tsx
@@ -55,7 +55,7 @@ export function FundraiserGallerySlider({
   };
 
   return (
-    <div className="relative w-full h-[379px] md:h-[600px] overflow-hidden rounded-none">
+    <div className="relative w-full aspect-[16/9] overflow-hidden rounded-none">
       <div
         className="flex w-full h-full transition-transform duration-500 ease-in-out"
         style={{ transform: `translateX(-${currentIndex * 100}%)` }}

--- a/frontend/src/app/buyer/fundraiser/[id]/page.tsx
+++ b/frontend/src/app/buyer/fundraiser/[id]/page.tsx
@@ -72,7 +72,7 @@ export default async function FundraiserPage({
         <ChevronLeft strokeWidth={2} className="h-8 w-8 text-stone-800" />
       </Link>
 
-      <div className="relative mb-10">
+      <div className="relative mb-10 px-4 md:px-[157px]">
         {fundraiser.imageUrls.length > 0 ? (
           <FundraiserGallerySlider images={fundraiser.imageUrls} />
         ) : (

--- a/frontend/src/app/buyer/fundraiser/[id]/page.tsx
+++ b/frontend/src/app/buyer/fundraiser/[id]/page.tsx
@@ -72,7 +72,7 @@ export default async function FundraiserPage({
         <ChevronLeft strokeWidth={2} className="h-8 w-8 text-stone-800" />
       </Link>
 
-      <div className="relative mb-10 px-4 md:px-[157px]">
+      <div className="relative mb-3 px-4 md:px-[157px]">
         {fundraiser.imageUrls.length > 0 ? (
           <FundraiserGallerySlider images={fundraiser.imageUrls} />
         ) : (

--- a/frontend/src/app/buyer/fundraiser/[id]/page.tsx
+++ b/frontend/src/app/buyer/fundraiser/[id]/page.tsx
@@ -76,7 +76,7 @@ export default async function FundraiserPage({
         {fundraiser.imageUrls.length > 0 ? (
           <FundraiserGallerySlider images={fundraiser.imageUrls} />
         ) : (
-          <div className="w-full h-[379px] md:h-[400px] bg-gray-200" />
+          <div className="w-full aspect-[16/9] bg-gray-200" />
         )}
       </div>
 

--- a/frontend/src/app/seller/org/[id]/create-fundraiser/components/FundraiserBasicInfoForm.tsx
+++ b/frontend/src/app/seller/org/[id]/create-fundraiser/components/FundraiserBasicInfoForm.tsx
@@ -108,6 +108,7 @@ export function FundraiserBasicInfoForm({
                     <Textarea
                       placeholder="Describe your fundraiser..."
                       {...field}
+                      maxLength={250}
                       className="min-h-24"
                     />
                   </FormControl>

--- a/frontend/src/components/custom/FundraiserCard.tsx
+++ b/frontend/src/components/custom/FundraiserCard.tsx
@@ -34,9 +34,9 @@ export function FundraiserCard({
   const isUpcoming = now < buyingStart;
 
   return (
-    <Card className="overflow-hidden border shadow-sm h-full flex flex-col hover:shadow-md hover:translate-y-[-2px] transition-all duration-200">
-      {/* Image Section */}
-      <div className="relative h-48 bg-gray-100">
+    <Card className="overflow-hidden border shadow-sm h-full flex flex-col md:flex-row hover:shadow-md hover:translate-y-[-2px] transition-all duration-200">
+      {/* Image Section - Left */}
+      <div className="relative w-full md:w-2/5 aspect-[16/9] bg-gray-100 flex-shrink-0">
         {fundraiser.imageUrls && fundraiser.imageUrls.length > 0 ? (
           <Image
             src={fundraiser.imageUrls[0]}
@@ -50,95 +50,78 @@ export function FundraiserCard({
             <span className="text-gray-400">No image</span>
           </div>
         )}
-
-        {/* Status Badge */}
-        <div
-          className={`absolute top-3 right-3 py-1 px-3 rounded-full text-xs font-medium ${
-            isBuyingActive
-              ? "bg-green-100 text-green-800"
-              : isUpcoming
-                ? "bg-blue-100 text-blue-800"
-                : "bg-gray-100 text-gray-800"
-          }`}
-        >
-          {isBuyingActive ? "Active" : isUpcoming ? "Upcoming" : "Ended"}
-        </div>
       </div>
 
-      <CardHeader className="pb-2">
-        <div className="flex justify-between items-start">
-          <div>
-            <CardTitle className="text-base">{fundraiser.name}</CardTitle>
-            <CardDescription className="flex items-center gap-1 mt-1">
-              {fundraiser.description}
-            </CardDescription>
-            {fundraiser.organization && (
-              <div className="text-xs text-gray-500 mt-1">
-                {fundraiser.organization.name}
-              </div>
-            )}
+      {/* Text Info Section - Right */}
+      <div className="flex flex-col flex-1 min-w-0">
+        <CardHeader className="pb-2">
+          <div className="flex justify-between items-start gap-2">
+            <div>
+              <CardTitle className="text-base">{fundraiser.name}</CardTitle>
+              <CardDescription className="flex items-center gap-1 mt-1">
+                {fundraiser.description}
+              </CardDescription>
+              {fundraiser.organization && (
+                <div className="text-xs text-gray-500 mt-1">
+                  {fundraiser.organization.name}
+                </div>
+              )}
+            </div>
+            {/* Status Badge */}
+            <div
+              className={`py-1 px-3 rounded-full text-xs font-medium flex-shrink-0 ${
+                isBuyingActive
+                  ? "bg-green-100 text-green-800"
+                  : isUpcoming
+                    ? "bg-blue-100 text-blue-800"
+                    : "bg-gray-100 text-gray-800"
+              }`}
+            >
+              {isBuyingActive ? "Active" : isUpcoming ? "Upcoming" : "Ended"}
+            </div>
           </div>
-        </div>
-      </CardHeader>
+        </CardHeader>
 
-      <CardContent className="pb-2 text-sm flex-1">
-        <div className="grid gap-2">
-          <div className="flex items-center gap-2">
-            <ShoppingBag className="h-4 w-4 text-muted-foreground" />
-            <span>
-              Buying Window:{" "}
-              <b>
-                <LocalDate date={fundraiser.buyingStartsAt} formatStr="MMM d 'at' h:mm a" /> -{" "}
-                <LocalDate date={fundraiser.buyingEndsAt} formatStr="MMM d 'at' h:mm a" />
-              </b>
-            </span>
-          </div>
-
-          <div className="flex flex-col gap-2">
+        <CardContent className="pb-2 text-sm flex-1">
+          <div className="grid gap-2">
             <div className="flex items-center gap-2">
-              <CalendarIcon className="h-4 w-4 text-muted-foreground" />
-              <span className="font-medium">
-                {fundraiser.pickupEvents.length === 1
-                  ? "Pickup Event"
-                  : `${fundraiser.pickupEvents.length} Pickup Events`}
+              <ShoppingBag className="h-4 w-4 text-muted-foreground" />
+              <span>
+                Buying Window:{" "}
+                <b>
+                  <LocalDate date={fundraiser.buyingStartsAt} formatStr="MMM d 'at' h:mm a" /> -{" "}
+                  <LocalDate date={fundraiser.buyingEndsAt} formatStr="MMM d 'at' h:mm a" />
+                </b>
               </span>
             </div>
-            {fundraiser.pickupEvents.map((event) => (
-              <div key={event.id} className="ml-6 text-xs space-y-1">
-                <div className="flex items-center gap-2">
-                  <MapPinIcon className="h-3 w-3 text-muted-foreground" />
-                  <span>
-                    <b>{event.location}</b>
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <CalendarIcon className="h-3 w-3 text-muted-foreground" />
-                  <span>
-                    <b>
-                      <LocalDate date={event.startsAt} formatStr="MMM d 'at' h:mm a" /> -{" "}
-                      <LocalDate date={event.endsAt} formatStr="MMM d 'at' h:mm a" />
-                    </b>
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </CardContent>
 
-      <CardFooter className="pt-2 flex mt-auto">
-        <Button variant="outline" size="sm" className="h-8" asChild>
-          <Link
-            href={
-              seller
-                ? `/seller/fundraiser/${fundraiser.id}`
-                : `/buyer/fundraiser/${fundraiser.id}`
-            }
-          >
-            View Details
-          </Link>
-        </Button>
-      </CardFooter>
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <CalendarIcon className="h-4 w-4 text-muted-foreground" />
+                <span className="font-medium">
+                  {fundraiser.pickupEvents.length === 1
+                    ? "1 Pickup Event"
+                    : `${fundraiser.pickupEvents.length} Pickup Events`}
+                </span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+
+        <CardFooter className="pt-2 flex mt-auto">
+          <Button variant="outline" size="sm" className="h-8" asChild>
+            <Link
+              href={
+                seller
+                  ? `/seller/fundraiser/${fundraiser.id}`
+                  : `/buyer/fundraiser/${fundraiser.id}`
+              }
+            >
+              View Details
+            </Link>
+          </Button>
+        </CardFooter>
+      </div>
     </Card>
   );
 }


### PR DESCRIPTION
- Enforces a consistent `aspect-[16/9]` ratio across all fundraiser image renderings, including:
   - browse fundraiser cards
   - detail-page gallery
   - shared `FundraiserCard`
   - no-image fallback
- Restructures `FundraiserCard` into a side-by-side layout (image on left, text on right) with the status badge moved into the text column
- Extracts the browse card into its own `BrowseFundraiserCard` component
- Caps the fundraiser description at 250 characters on the seller form to prevent long descriptions from breaking card layouts



**New fundraiser card under organization tab**
<img width="1226" height="585" alt="image" src="https://github.com/user-attachments/assets/dab97d7b-c6ec-46cd-bcf6-6aaa7fd949b0" />


**New Browse Fundraiser Card**
<img width="1276" height="780" alt="image" src="https://github.com/user-attachments/assets/3db9d08a-9553-4daa-b930-bc1d70e1fc91" />


**New fundraiser detail page**
<img width="1504" height="908" alt="image" src="https://github.com/user-attachments/assets/cddeca15-d835-4f79-97ba-7148e151a329" />

